### PR TITLE
Introduce `EngineAddon` extension.

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,18 @@ described above.
 
 ### Configuring your Engine
 
+Within your engine's root directory, modify `index.js` so that your addon
+is configured as an engine using the `EngineAddon` extension:
+
+```js
+/*jshint node:true*/
+var EngineAddon = require('ember-engines/lib/engine-addon');
+
+module.exports = EngineAddon.extend({
+  name: 'ember-blog'
+});
+```
+
 Within your engine's `addon` directory, add a new `engine.js` file:
 
 ```js

--- a/bin/install-test-addons.sh
+++ b/bin/install-test-addons.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+mkdir -p node_modules
+
+rm -rf node_modules/common-components
+ln -s ../tests/dummy/lib/common-components node_modules/common-components
+
 rm -rf node_modules/ember-blog
 ln -s ../tests/dummy/lib/ember-blog node_modules/ember-blog
 

--- a/lib/engine-addon.js
+++ b/lib/engine-addon.js
@@ -1,0 +1,48 @@
+var Funnel = require('broccoli-funnel');
+var mergeTrees = require('broccoli-merge-trees');
+
+module.exports = {
+  extend: function(options) {
+    if (options.treeFor) {
+      throw new Error('Do not provide a custom `options.treeFor` with `EngineAddon.extend(options)`.');
+    }
+
+    options.treeFor = function treeFor(name) {
+      var tree, trees;
+
+      this._requireBuildPackages();
+
+      if (name === 'app') {
+        trees = [];
+      } else {
+        trees = this.eachAddonInvoke('treeFor', [name]);
+
+        if (name === 'addon') {
+          var appTree = mergeTrees(this.eachAddonInvoke('treeFor', ['app']), {
+            overwrite: true,
+            annotation: 'Engine#treeFor (' + options.name + ' - ' + name + ')'
+          });
+          var funneledAppTree = new Funnel(appTree, {
+            destDir: 'modules/' + options.name
+          });
+          trees.push(funneledAppTree);
+        }
+      }
+
+      if (tree = this._treeFor(name)) {
+        trees.push(tree);
+      }
+
+      if (this.isDevelopingAddon() && this.hintingEnabled() && name === 'app') {
+        trees.push(this.jshintAddonTree());
+      }
+
+      return mergeTrees(trees.filter(Boolean), {
+        overwrite: true,
+        annotation: 'Engine#treeFor (' + options.name + ' - ' + name + ')'
+      });
+    };
+
+    return options;
+  }
+}

--- a/package.json
+++ b/package.json
@@ -26,6 +26,8 @@
   "license": "MIT",
   "devDependencies": {
     "broccoli-asset-rev": "^2.2.0",
+    "broccoli-funnel": "^1.0.0",
+    "broccoli-merge-trees": "^1.0.0",
     "ember-ajax": "0.7.1",
     "ember-cli": "2.2.0-beta.2",
     "ember-cli-app-version": "^1.0.0",

--- a/tests/acceptance/routeless-engine-demo-test.js
+++ b/tests/acceptance/routeless-engine-demo-test.js
@@ -1,0 +1,15 @@
+import { test } from 'qunit';
+import moduleForAcceptance from '../../tests/helpers/module-for-acceptance';
+
+moduleForAcceptance('Acceptance | routeless engine demo');
+
+test('can invoke components directly in an engine and also that are dependencies of an engine', function(assert) {
+  visit('/routeless-engine-demo');
+
+  andThen(() => {
+    assert.equal(currentURL(), '/routeless-engine-demo');
+
+    assert.equal(this.application.$('.hello .greeting').text().trim(), 'Hello');
+    assert.equal(this.application.$('.hola .greeting').text().trim(), 'Hola');
+  });
+});

--- a/tests/dummy/lib/common-components/addon/components/spanish-greeting.js
+++ b/tests/dummy/lib/common-components/addon/components/spanish-greeting.js
@@ -1,0 +1,7 @@
+import Ember from 'ember';
+import layout from '../templates/components/spanish-greeting';
+
+export default Ember.Component.extend({
+  layout: layout,
+  name: null
+});

--- a/tests/dummy/lib/common-components/addon/templates/components/spanish-greeting.hbs
+++ b/tests/dummy/lib/common-components/addon/templates/components/spanish-greeting.hbs
@@ -1,0 +1,1 @@
+<span class="greeting">Hola</span> {{name}}!

--- a/tests/dummy/lib/common-components/app/components/spanish-greeting.js
+++ b/tests/dummy/lib/common-components/app/components/spanish-greeting.js
@@ -1,0 +1,1 @@
+export { default } from 'common-components/components/spanish-greeting';

--- a/tests/dummy/lib/common-components/index.js
+++ b/tests/dummy/lib/common-components/index.js
@@ -1,8 +1,6 @@
 /*jshint node:true*/
-var EngineAddon = require('../../../../lib/engine-addon');
-
-module.exports = EngineAddon.extend({
-  name: 'ember-chat',
+module.exports = {
+  name: 'common-components',
 
   isDevelopingAddon: function() {
     return true;
@@ -11,4 +9,4 @@ module.exports = EngineAddon.extend({
   hintingEnabled: function() {
     return false;
   }
-});
+};

--- a/tests/dummy/lib/common-components/package.json
+++ b/tests/dummy/lib/common-components/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "common-components",
+  "keywords": [
+    "ember-addon"
+  ],
+  "dependencies": {
+    "ember-cli-htmlbars": "*"
+  }
+}

--- a/tests/dummy/lib/ember-blog/index.js
+++ b/tests/dummy/lib/ember-blog/index.js
@@ -1,5 +1,7 @@
 /*jshint node:true*/
-module.exports = {
+var EngineAddon = require('../../../../lib/engine-addon');
+
+module.exports = EngineAddon.extend({
   name: 'ember-blog',
 
   isDevelopingAddon: function() {
@@ -9,4 +11,4 @@ module.exports = {
   hintingEnabled: function() {
     return false;
   }
-};
+});

--- a/tests/dummy/lib/ember-chat/addon/templates/application.hbs
+++ b/tests/dummy/lib/ember-chat/addon/templates/application.hbs
@@ -1,5 +1,7 @@
 <div class="engine">
   Engine: {{name}}
 
-  {{hello-world name=name}}
+  <div class="hello">{{hello-world name=name}}</div>
+
+  <div class="hola">{{spanish-greeting name=name}}</div>
 </div>

--- a/tests/dummy/lib/ember-chat/addon/templates/components/hello-world.hbs
+++ b/tests/dummy/lib/ember-chat/addon/templates/components/hello-world.hbs
@@ -1,1 +1,1 @@
-Hello from {{name}}!
+<span class="greeting">Hello</span> from {{name}}!

--- a/tests/dummy/lib/ember-chat/package.json
+++ b/tests/dummy/lib/ember-chat/package.json
@@ -6,6 +6,7 @@
     "ember-engine"
   ],
   "dependencies": {
-    "ember-cli-htmlbars": "*"
+    "ember-cli-htmlbars": "*",
+    "common-components": "*"
   }
 }


### PR DESCRIPTION
The EngineAddon extension ensures that an engine is able to access
addon dependencies as if it is an application. This is accomplished
by merging each addon’s `app` tree into the engine’s module
namespace.