### PR TITLE
EmberAddon dependencies are not devDependencies.

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,8 +26,6 @@
   "license": "MIT",
   "devDependencies": {
     "broccoli-asset-rev": "^2.2.0",
-    "broccoli-funnel": "^1.0.0",
-    "broccoli-merge-trees": "^1.0.0",
     "ember-ajax": "0.7.1",
     "ember-cli": "2.2.0-beta.2",
     "ember-cli-app-version": "^1.0.0",
@@ -50,6 +48,8 @@
     "ember-addon"
   ],
   "dependencies": {
+    "broccoli-funnel": "^1.0.0",
+    "broccoli-merge-trees": "^1.0.0",
     "ember-cli-htmlbars": "^1.0.1",
     "ember-cli-babel": "^5.1.5"
   },


### PR DESCRIPTION
broccoli-funnel and broccoli-merge-trees need to be available to
engine projects.