### PR TITLE
Make mount#rerender more robust.

### DIFF
--- a/addon/-private/keywords/mount.js
+++ b/addon/-private/keywords/mount.js
@@ -226,8 +226,11 @@ registerKeyword('mount', {
   },
 
   rerender(node, env, scope, params /*, hash, template, inverse, visitor */) {
-    var model = read(params[1]);
-    node.getState().controller.set('model', model);
+    let controller = node.getState().controller;
+    if (controller) {
+      let model = read(params[1]);
+      controller.set('model', model);
+    }
   }
 });
 


### PR DESCRIPTION
Ensure that a controller is available before attempting to set its model. This fixes a scenario when a route-less engine is mounted alongside a routable engine, and then the routable engine is 
visited. We will need further testing to fully understand the problem that this fixes.