### PR TITLE
Fix error when legacy view support is on.

### DIFF
--- a/addon/-private/engine-ext.js
+++ b/addon/-private/engine-ext.js
@@ -1,12 +1,12 @@
 import Ember from 'ember';
 import emberRequire from './ext-require';
 
+const SelectView = emberRequire('ember-views/views/select');
 const EmberView = emberRequire('ember-views/views/view');
 const RoutingService = emberRequire('ember-routing/services/routing');
 const Engine = emberRequire('ember-application/system/engine');
 
 const {
-  SelectView,
   OutletView,
   TextField,
   TextArea,


### PR DESCRIPTION
When `Ember.ENV._ENABLE_LEGACY_VIEW_SUPPORT` is on, the following error occurs, preventing the app from loading:

<pre>
TypeError: Attempting to register an unknown factory: `view:select`
</pre>

This change to use Ember's dependency injection fixes the issue.

See issue #69.