### PR TITLE
Quick hack to demonstrate linking between engines

### DIFF
--- a/addon/-private/engine-instance-ext.js
+++ b/addon/-private/engine-instance-ext.js
@@ -69,7 +69,7 @@ EngineInstance.reopen({
         let engineDependencies = engineConfiguration.dependencies;
 
         if (engineDependencies) {
-          ['services'].forEach((category) => {
+          ['services', 'urls'].forEach((category) => {
             if (engineDependencies[category]) {
               dependencies[category] = {};
               let dependencyType = this._dependencyTypeFromCategory(category);
@@ -215,7 +215,8 @@ EngineInstance.reopen({
       'route:basic',
       'event_dispatcher:main',
       '-bucket-cache:main',
-      'service:-routing'
+      'service:-routing',
+      'helper:get-url'
     ].forEach((key) => {
       this.register(key, parent.resolveRegistration(key));
     });
@@ -240,7 +241,6 @@ EngineInstance.reopen({
           let key = `${dependencyType}:${dependencyName}`;
 
           let dependency = this.dependencies[category] && this.dependencies[category][dependencyName];
-
           assert(`A dependency mapping for '${category}.${dependencyName}' must be declared on this engine's parent.`, dependency);
 
           this.register(key, dependency, { instantiate: false });
@@ -253,6 +253,8 @@ EngineInstance.reopen({
     switch(category) {
       case 'services':
         return 'service';
+      case 'urls':
+        return 'url';
     }
     assert(`Dependencies of category '${category}' can not be shared with engines.`, false);
   },

--- a/addon/-private/global-url.js
+++ b/addon/-private/global-url.js
@@ -1,0 +1,10 @@
+function GlobalUrl(url) {
+  this.url = url;
+  this.isGlobalUrl = true;
+}
+
+GlobalUrl.prototype.toString = function() {
+  return '' + this.url;
+};
+
+export default GlobalUrl;

--- a/addon/-private/link-to-component-ext.js
+++ b/addon/-private/link-to-component-ext.js
@@ -14,9 +14,13 @@ LinkComponent.reopen({
     let owner = getOwner(this);
 
     if (owner.mountPoint) {
-      let fullRouteName = owner.mountPoint + '.' + get(this, 'targetRouteName');
-
-      set(this, 'targetRouteName', fullRouteName);
+      let targetRouteName = get(this, 'targetRouteName');
+      if (!targetRouteName.isGlobalUrl) {
+        let fullRouteName = owner.mountPoint + '.' + targetRouteName;
+        set(this, 'targetRouteName', fullRouteName);
+      } else {
+        set(this, 'targetRouteName', targetRouteName.toString());
+      }
     }
   }
 });

--- a/addon/-private/router-dsl-ext.js
+++ b/addon/-private/router-dsl-ext.js
@@ -55,13 +55,14 @@ EmberRouterDSL.prototype.push = function(url, fullName, callback) {
   if (this.options.engineInfo) {
     let localFullName = fullName.slice(this.options.engineInfo.fullName.length + 1);
     let routeInfo = merge({ localFullName }, this.options.engineInfo);
-
     this.options.addRouteForEngine(fullName, routeInfo);
   }
 
   if (url === '' || url === '/' || parts[parts.length - 1] === 'index') {
     this.explicitIndex = true;
   }
+
+  this.options.addUrl(fullName);
 
   this.matches.push([url, fullName, callback]);
 };

--- a/addon/-private/router-ext.js
+++ b/addon/-private/router-ext.js
@@ -18,6 +18,7 @@ EmberRouter.reopen({
 
     this._engineInstances = new EmptyObject();
     this._routeToEngineInfoXRef = new EmptyObject();
+    this._urls = [];
   },
 
   /*
@@ -38,6 +39,10 @@ EmberRouter.reopen({
 
       addRouteForEngine(name, engineInfo) {
         router._routeToEngineInfoXRef[name] = engineInfo;
+      },
+
+      addUrl(url) {
+        router._urls.push(url);
       }
     });
   },
@@ -120,5 +125,18 @@ EmberRouter.reopen({
 
       return handler;
     };
+  },
+
+  setupRouter: function() {
+    let ret = this._super(...arguments);
+
+    let owner = getOwner(this);
+    let urls = this._urls;
+    urls.forEach(url => {
+        owner.register(`url:${url}`, Ember.Object.extend({url: url}));
+    });
+
+
+    return ret;
   }
 });

--- a/addon/helpers/get-url.js
+++ b/addon/helpers/get-url.js
@@ -1,0 +1,16 @@
+import Ember from 'ember';
+import GlobalUrl from '../-private/global-url';
+
+const {
+  get,
+  getOwner
+} = Ember;
+
+
+export default Ember.Helper.extend({
+  compute(name) {
+    let urlInfo = getOwner(this).lookup(`url:${name}`);
+    let url = get(urlInfo, 'url');
+    return new GlobalUrl(url);
+  }
+});

--- a/app/helpers/get-url.js
+++ b/app/helpers/get-url.js
@@ -1,0 +1,1 @@
+export {default} from 'ember-engines/helpers/get-url';

--- a/tests/acceptance/routeable-engine-demo-test.js
+++ b/tests/acceptance/routeable-engine-demo-test.js
@@ -13,6 +13,21 @@ test('can invoke components', function(assert) {
   });
 });
 
+test('can link to external routes', function(assert) {
+  visit('/routable-engine-demo/blog/new');
+
+  andThen(() => {
+    assert.equal(currentURL(), '/routable-engine-demo/blog/new');
+    assert.equal(this.application.$('.new-user-link').attr('href'), '/users/new');
+  });
+
+  click('.new-user-link');
+  andThen(() => {
+    assert.equal(currentURL(), '/users/new');
+    assert.equal(this.application.$('.title').text().trim(), 'New user');
+  });
+});
+
 test('can deserialize a route\'s params', function(assert) {
   assert.expect(2);
 

--- a/tests/dummy/app/app.js
+++ b/tests/dummy/app/app.js
@@ -17,6 +17,9 @@ App = Ember.Application.extend({
       dependencies: {
         services: [
           {'data-store': 'store'}
+        ],
+        urls: [
+          {'new-user': 'users.new'}
         ]
       }
     },

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -21,6 +21,11 @@ Router.map(function() {
 
     this.mount('ember-blog', { as: 'admin-blog', path: '/special-admin-blog-here' });
   });
+
+  this.route('users', function() {
+    this.route('new');
+  });
+  
 });
 
 export default Router;

--- a/tests/dummy/app/templates/users/new.hbs
+++ b/tests/dummy/app/templates/users/new.hbs
@@ -1,0 +1,1 @@
+<h1 class="title">New user</h1>

--- a/tests/dummy/lib/ember-blog/addon/engine.js
+++ b/tests/dummy/lib/ember-blog/addon/engine.js
@@ -9,6 +9,9 @@ export default Engine.extend({
   dependencies: {
     services: [
       'data-store'
+    ],
+    urls: [
+      'new-user'
     ]
   }
 });

--- a/tests/dummy/lib/ember-blog/addon/templates/new.hbs
+++ b/tests/dummy/lib/ember-blog/addon/templates/new.hbs
@@ -3,6 +3,8 @@
 
   {{hello-world class="routable-hello-world"}}
 
+  {{#link-to (get-url 'new-user') class="new-user-link"}}New user{{/link-to}}<br>
+
   <button {{action 'goAway'}} class="trigger-transition-to">Go Away!</button>
   <button {{action 'goAwayViaURL'}} class="trigger-transition-to-url">Go Away via URL!</button>
 </div>


### PR DESCRIPTION
This is a quick hack to demonstrate linking between engines. It's motivated by this comment: https://github.com/emberjs/rfcs/pull/122#issuecomment-186496767

I think we can provide URLs for the engine in the same way we provide services. `url` is not the correct term, I'm using it here just because I could not think of a better name.

```js
// Engine declaration
export default Engine.extend({
  dependencies: {
    services: [
      'store',
    ],
    urls: [
      'new-user',
      'help'
    ]
  }
});
```


```js
// Application using that engine
App = Ember.Application.extend({
  engines: {
    emberBlog: {
      dependencies: {
        services: [
          'store'
        ],
        urls: [
          {'new-user': 'users.new'},
          {'help': 'help.blog'}
        ]
      }
    }
  }
});
```

```hbs
{{! links to external urls }}
{{#link-to get-url('new-user')}}Create user{{/link-to}}
{{#link-to get-url('help')}}Help{{/link-to}}
```

Note, this is just a hack to demonstrate my point in that RFC. Please don't merge. :smile: 
