### PR TITLE
External links / linking between engines

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ consumers or providers of engines. The following functionality is supported:
 * Route-less engines, which can be rendered in a template using the `{{mount}}`
   keyword.
 * Sharing of dependencies from parents (applications or other engines) to
-  contained engines. Shared dependencies are currently limited to services.
+  contained engines. Shared dependencies are currently limited to services
+  and route paths.
 
 The following functionality will soon be supported:
 
@@ -24,7 +25,7 @@ The following functionality will soon be supported:
 Support for the following concepts is under consideration:
 
 * Namespaced access to engine resources from applications.
-* Sharing of dependencies other than services.
+* Sharing of dependencies other than services and route paths.
 * Passing configuration attributes from an engine's parent.
 
 ## Introduction Video
@@ -162,7 +163,65 @@ export default Engine.extend({
 });
 ```
 
-Currently, only services can be shared across the parent/engine boundary.
+Currently, only services and route paths (see below) can be shared across the
+parent/engine boundary.
+
+### Linking To External Routes
+
+Linking to routes outside of an Engine's isolated context is currently supported
+by defining "external routes" as dependencies of your Engine.
+
+You specify **what** external things your Engine wants to link to by providing
+an array of names like so:
+
+```js
+// ember-blog/addon/engine.js
+export default Engine.extend({
+  // ...
+  dependencies: {
+    externalRoutes: [
+      'home',
+      'settings'
+    ]
+  }
+});
+```
+
+The Engine's consumer is then responsible for defining **where** those things are
+located via a route path:
+
+```js
+// dummy/app/app.js
+const App = Ember.Application.extend({
+  modulePrefix: config.modulePrefix,
+  podModulePrefix: config.podModulePrefix,
+  Resolver,
+
+  engines: {
+    emberBlog: {
+      dependencies: {
+        externalRoutes: {
+          home: 'home.index',
+          settings: 'settings.blog.index'
+        }
+      }
+    }
+  }
+});
+```
+You can then use those external routes either programmatically or within a
+template like so:
+
+```hbs
+{{#link-to-external 'home'}}Go home{{/link-to-external}}
+```
+
+```js
+// ember-blog/addon/some-route.js
+this.transitionToExternal('settings');
+```
+
+For further documentation on this subject, view the [Engine Linking RFC](https://github.com/emberjs/rfcs/pull/122).
 
 ## Consuming Engines
 

--- a/addon/-private/engine-ext.js
+++ b/addon/-private/engine-ext.js
@@ -1,4 +1,6 @@
 import Ember from 'ember';
+import LinkComponent from './link-to-component';
+import ExternalLinkComponent from './link-to-external-component';
 import emberRequire from './ext-require';
 
 const EmberView = emberRequire('ember-views/views/view');
@@ -13,8 +15,7 @@ const {
   TextArea,
   Checkbox,
   ContainerDebugAdapter,
-  ComponentLookup,
-  LinkComponent
+  ComponentLookup
 } = Ember;
 
 Engine.reopen({
@@ -71,6 +72,7 @@ Engine.reopen({
       registry.register('component:-checkbox', Checkbox);
       // registry.register('view:-legacy-each', LegacyEachView);
       registry.register('component:link-to', LinkComponent);
+      registry.register('component:link-to-external', ExternalLinkComponent);
 
       // Register the routing service...
       registry.register('service:-routing', RoutingService);

--- a/addon/-private/link-to-component.js
+++ b/addon/-private/link-to-component.js
@@ -7,7 +7,7 @@ const {
   set
 } = Ember;
 
-LinkComponent.reopen({
+export default LinkComponent.extend({
   willRender() {
     this._super(...arguments);
 

--- a/addon/-private/link-to-external-component.js
+++ b/addon/-private/link-to-external-component.js
@@ -1,0 +1,19 @@
+import Ember from 'ember';
+
+const {
+  LinkComponent,
+  getOwner,
+  get,
+  set
+} = Ember;
+
+export default LinkComponent.extend({
+  willRender() {
+    this._super(...arguments);
+
+    const owner = getOwner(this);
+    const targetRouteName = get(this, 'targetRouteName');
+    const externalRoute = owner._getExternalRoute(targetRouteName);
+    set(this, 'targetRouteName', externalRoute);
+  }
+});

--- a/addon/-private/route-ext.js
+++ b/addon/-private/route-ext.js
@@ -32,6 +32,16 @@ function prefixRouteNameArg(...args) {
   return args;
 }
 
+/*
+  Creates an aliased form of a method that properly resolves external routes.
+*/
+function externalAlias(methodName) {
+  return function _externalAliasMethod(routeName, ...args) {
+    let externalRoute = getOwner(this)._getExternalRoute(routeName);
+    this.router[methodName](externalRoute, ...args);
+  };
+}
+
 Route.reopen({
   paramsFor(name) {
     let owner = getOwner(this);
@@ -68,6 +78,10 @@ Route.reopen({
   transitionTo(...args) {
     return this._super.apply(this, (prefixRouteNameArg.call(this, ...args)));
   },
+
+  transitionToExternal: externalAlias('transitionTo'),
+
+  replaceWithExternal: externalAlias('replaceWith'),
 
   modelFor(_routeName, ...args) {
     let routeName = _routeName;

--- a/addon/-private/router-ext.js
+++ b/addon/-private/router-ext.js
@@ -72,7 +72,6 @@ EmberRouter.reopen({
     return engineInstance;
   },
 
-
   /*
     Overridden to use the passed in `info` object as an object (previously a string
     representing the route name).

--- a/addon/initializers/engines.js
+++ b/addon/initializers/engines.js
@@ -6,7 +6,6 @@ import '../-private/engine-instance-ext';
 import '../-private/keywords/mount';
 import '../-private/keywords/outlet';
 import '../-private/router-dsl-ext';
-import '../-private/link-to-component-ext';
 
 // TODO: Move to ensure they run prior to instantiating Ember.Application
 export function initialize() {

--- a/tests/acceptance/routeable-engine-demo-test.js
+++ b/tests/acceptance/routeable-engine-demo-test.js
@@ -55,6 +55,17 @@ test('internal links can be clicked', function(assert) {
   assert.expect(1);
 
   visit('/routable-engine-demo/blog/post/1');
+  click('.routable-post-home-link');
+
+  andThen(() => {
+    assert.equal(currentURL(), '/');
+  });
+});
+
+test('external links can be clicked', function(assert) {
+  assert.expect(1);
+
+  visit('/routable-engine-demo/blog/post/1');
   click('.routable-post-comments-link');
 
   andThen(() => {

--- a/tests/dummy/app/app.js
+++ b/tests/dummy/app/app.js
@@ -17,7 +17,10 @@ App = Ember.Application.extend({
       dependencies: {
         services: [
           {'data-store': 'store'}
-        ]
+        ],
+        externalRoutes: {
+          home: 'application'
+        }
       }
     },
     emberChat: {

--- a/tests/dummy/lib/ember-blog/addon/engine.js
+++ b/tests/dummy/lib/ember-blog/addon/engine.js
@@ -9,6 +9,9 @@ export default Engine.extend({
   dependencies: {
     services: [
       'data-store'
+    ],
+    externalRoutes: [
+      'home'
     ]
   }
 });

--- a/tests/dummy/lib/ember-blog/addon/templates/post.hbs
+++ b/tests/dummy/lib/ember-blog/addon/templates/post.hbs
@@ -2,6 +2,8 @@
 
 <p class="author">{{model.user.name}}</p>
 
-{{#link-to 'post.comments' 1 class="routable-post-comments-link"}}Comments{{/link-to}}
+{{#link-to "post.comments" 1 class="routable-post-comments-link"}}Comments{{/link-to}}
 
 {{outlet}}
+
+{{#link-to-external "home" class="routable-post-home-link"}}Go home{{/link-to-external}}


### PR DESCRIPTION
This is a proof-of-concept for the recent updates to emberjs/rfcs#122 which attempts to address #57.

I would definitely like to see this feature move along, so I will update this branch with any future iterations on the RFC. This is last main feature I would need before using Engines in production projects.