### PR TITLE
Allow getting the modelFor application route

### DIFF
--- a/addon/-private/route-ext.js
+++ b/addon/-private/route-ext.js
@@ -62,7 +62,11 @@ Route.reopen({
 
     if (owner.routable) {
       let prefix = owner.mountPoint;
-      routeName = `${prefix}.${_routeName}`;
+      if (routeName === 'application') {
+        routeName = prefix;
+      } else {
+        routeName = `${prefix}.${_routeName}`;
+      }
     }
 
     return this._super(routeName, ...args);

--- a/tests/acceptance/routeable-engine-demo-test.js
+++ b/tests/acceptance/routeable-engine-demo-test.js
@@ -14,7 +14,7 @@ test('can invoke components', function(assert) {
 });
 
 test('can deserialize a route\'s params', function(assert) {
-  assert.expect(2);
+  assert.expect(3);
 
   visit('/routable-engine-demo/blog/post/1');
 
@@ -22,6 +22,7 @@ test('can deserialize a route\'s params', function(assert) {
     assert.equal(currentURL(), '/routable-engine-demo/blog/post/1');
 
     assert.equal(this.application.$('h3.post-title').text().trim(), 'Post 1');
+    assert.equal(this.application.$('p.author').text().trim(), 'Derek Zoolander');
   });
 });
 

--- a/tests/dummy/lib/ember-blog/addon/routes/application.js
+++ b/tests/dummy/lib/ember-blog/addon/routes/application.js
@@ -3,5 +3,8 @@ import Ember from 'ember';
 export default Ember.Route.extend({
   model() {
     console.log('ember-chat.application route model hook');
+    return {
+      name: 'Derek Zoolander'
+    };
   }
 });

--- a/tests/dummy/lib/ember-blog/addon/routes/post.js
+++ b/tests/dummy/lib/ember-blog/addon/routes/post.js
@@ -4,6 +4,7 @@ export default Ember.Route.extend({
   model(params) {
     console.log('ember-blog.post route model hook', params);
     return {
+      user: this.modelFor('application'),
       id: params.id,
       title: `Post ${params.id}`
     };

--- a/tests/dummy/lib/ember-blog/addon/templates/post.hbs
+++ b/tests/dummy/lib/ember-blog/addon/templates/post.hbs
@@ -1,5 +1,7 @@
 <h3 class="post-title">{{model.title}}</h3>
 
+<p class="author">{{model.user.name}}</p>
+
 {{#link-to 'post.comments' 1 class="routable-post-comments-link"}}Comments{{/link-to}}
 
 {{outlet}}


### PR DESCRIPTION
Currently, `modelFor` in an Engine does not allow you to get the model from the `application` route, this is a simple fix to allow that.