### PR TITLE
Fix environment owner during re-render

### DIFF
--- a/tests/acceptance/routeable-engine-demo-test.js
+++ b/tests/acceptance/routeable-engine-demo-test.js
@@ -10,6 +10,7 @@ test('can invoke components', function(assert) {
     assert.equal(currentURL(), '/routable-engine-demo/blog/new');
 
     assert.equal(this.application.$('.routable-hello-world').text().trim(), 'Hello, world!');
+    assert.equal(this.application.$('.hello-name').text().trim(), 'Hello, Jerry!', 'Re-rendered hello-name component correctly');
   });
 });
 

--- a/tests/dummy/lib/ember-blog/addon/components/hello-name.js
+++ b/tests/dummy/lib/ember-blog/addon/components/hello-name.js
@@ -1,0 +1,11 @@
+import Ember from 'ember';
+import layout from '../templates/components/hello-name';
+
+export default Ember.Component.extend({
+  layout: layout,
+  classNames: [ 'hello-name' ],
+  init() {
+    this._super(...arguments);
+    Ember.run.later(() => this.set('name', 'Jerry'), 500);
+  }
+});

--- a/tests/dummy/lib/ember-blog/addon/templates/application.hbs
+++ b/tests/dummy/lib/ember-blog/addon/templates/application.hbs
@@ -1,0 +1,3 @@
+{{hello-name name="Ben"}}
+
+{{outlet}}

--- a/tests/dummy/lib/ember-blog/addon/templates/components/hello-name.hbs
+++ b/tests/dummy/lib/ember-blog/addon/templates/components/hello-name.hbs
@@ -1,0 +1,1 @@
+Hello, {{name}}!


### PR DESCRIPTION
Addressing #85 to the best of my ability.

**Root Issue**: During re-render, the `env.owner` was not correct within an `outlet`. This was because `outlet.render` was not called, meaning that the check for ensuring the proper `owner` never occurred.

**Solution:** Move the check for `owner` into `outlet.childEnv`, which is called on initial and subsequent render.

I'm not 100% certain this is the best solution as I still don't fully understand the rendering flows and hooks, but it works. I've included a previously failing test as well.

cc @krisselden 