### PR TITLE
Run initializers and instance-initializers inside engines

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,10 +100,8 @@ import Engine from 'ember-engines/engine';
 import Resolver from 'ember-engines/resolver';
 import loadInitializers from 'ember-load-initializers';
 
-let Eng;
 const modulePrefix = 'ember-blog';
-
-Eng = Engine.extend({
+const Eng = Engine.extend({
   modulePrefix,
   Resolver
 });

--- a/README.md
+++ b/README.md
@@ -98,12 +98,20 @@ Within your engine's `addon` directory, add a new `engine.js` file:
 ```js
 import Engine from 'ember-engines/engine';
 import Resolver from 'ember-engines/resolver';
+import loadInitializers from 'ember-load-initializers';
 
-export default Engine.extend({
-  modulePrefix: 'ember-blog',
+let Eng;
+const modulePrefix = 'ember-blog';
 
+Eng = Engine.extend({
+  modulePrefix,
   Resolver
 });
+
+loadInitializers(Eng, modulePrefix);
+
+export default Eng;
+
 ```
 
 It's important to define a `modulePrefix` that will be used to resolve your

--- a/addon/-private/engine-ext.js
+++ b/addon/-private/engine-ext.js
@@ -18,6 +18,20 @@ const {
 } = Ember;
 
 Engine.reopen({
+  _initializersRan: false,
+
+  ensureInitializers() {
+    if (!this._initializersRan) {
+      this.runInitializers();
+      this._initializersRan = true;
+    }
+  },
+
+  buildInstance(options) {
+    this.ensureInitializers();
+    return this._super(options);
+  },
+
   buildRegistry() {
     let namespace = this;
     let registry = this._super(...arguments);

--- a/blueprints/in-repo-engine/routable-files/lib/__name__/addon/engine.js
+++ b/blueprints/in-repo-engine/routable-files/lib/__name__/addon/engine.js
@@ -1,7 +1,13 @@
 import Engine from 'ember-engines/engine';
 import Resolver from 'ember-engines/resolver';
+import loadInitializers from 'ember-load-initializers';
 
-export default Engine.extend({
-  modulePrefix: '<%= dasherizedModuleName %>',
+const modulePrefix = 'ember-blog';
+const Eng = Engine.extend({
+  modulePrefix,
   Resolver
 });
+
+loadInitializers(Eng, modulePrefix);
+
+export default Eng;

--- a/blueprints/in-repo-engine/routeless-files/lib/__name__/addon/engine.js
+++ b/blueprints/in-repo-engine/routeless-files/lib/__name__/addon/engine.js
@@ -1,7 +1,13 @@
 import Engine from 'ember-engines/engine';
 import Resolver from 'ember-engines/resolver';
+import loadInitializers from 'ember-load-initializers';
 
-export default Engine.extend({
-  modulePrefix: '<%= dasherizedModuleName %>',
+const modulePrefix = 'ember-blog';
+const Eng = Engine.extend({
+  modulePrefix,
   Resolver
 });
+
+loadInitializers(Eng, modulePrefix);
+
+export default Eng;

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "ember-export-application-global": "^1.0.5",
     "ember-load-initializers": "^0.5.1",
     "ember-resolver": "^2.0.3",
+    "ember-sinon": "0.5.0",
     "ember-try": "^0.2.2",
     "loader.js": "^4.0.1"
   },

--- a/tests/acceptance/routeable-engine-demo-test.js
+++ b/tests/acceptance/routeable-engine-demo-test.js
@@ -1,5 +1,8 @@
 import { test } from 'qunit';
+import sinon from 'sinon';
 import moduleForAcceptance from '../../tests/helpers/module-for-acceptance';
+import Initializer from 'ember-blog/initializers/ember-blog-initializer';
+import InstanceInitializer from 'ember-blog/instance-initializers/ember-blog-instance-initializer';
 
 moduleForAcceptance('Acceptance | routable engine demo');
 
@@ -91,5 +94,31 @@ test('transitionTo works properly within parent application', function(assert) {
 
   andThen(() => {
     assert.equal(currentURL(), '/routeless-engine-demo');
+  });
+});
+
+test('initializers run within engine', function(assert) {
+  assert.expect(1);
+
+  let stub = sinon.stub(Initializer, 'initialize');
+
+  visit('/routable-engine-demo/blog/new');
+
+  andThen(() => {
+    assert.ok(stub.calledOnce, 'Initializer ran once');
+    stub.restore();
+  });
+});
+
+test('instance initializers run within engine', function(assert) {
+  assert.expect(1);
+
+  let stub = sinon.stub(InstanceInitializer, 'initialize');
+
+  visit('/routable-engine-demo/blog/new');
+
+  andThen(() => {
+    assert.ok(stub.calledOnce, 'Instance initializer ran once');
+    stub.restore();
   });
 });

--- a/tests/acceptance/routeable-engine-demo-test.js
+++ b/tests/acceptance/routeable-engine-demo-test.js
@@ -122,3 +122,26 @@ test('instance initializers run within engine', function(assert) {
     stub.restore();
   });
 });
+
+test('instance-initializers run after initializers', function(assert) {
+  assert.expect(2);
+
+  let appInitialized = false;
+  let instanceInitialized = false;
+
+  let appInit = sinon.stub(Initializer, 'initialize', function() {
+    appInitialized = true;
+    assert.ok(!instanceInitialized, 'instance initialized has not run yet');
+  });
+  let instanceInit = sinon.stub(InstanceInitializer, 'initialize', function() {
+    instanceInitialized = true;
+    assert.ok(appInitialized, 'initializer already ran');
+  });
+
+  visit('/routable-engine-demo/blog/new');
+
+  andThen(() => {
+    appInit.restore();
+    instanceInit.restore();
+  });
+});

--- a/tests/dummy/lib/ember-blog/addon/engine.js
+++ b/tests/dummy/lib/ember-blog/addon/engine.js
@@ -1,9 +1,13 @@
 import Engine from 'ember-engines/engine';
 import Resolver from 'ember-engines/resolver';
+import loadInitializers from 'ember-load-initializers';
 
-export default Engine.extend({
-  modulePrefix: 'ember-blog',
+let Eng;
 
+const modulePrefix = 'ember-blog';
+
+Eng = Engine.extend({
+  modulePrefix,
   Resolver,
 
   dependencies: {
@@ -12,3 +16,7 @@ export default Engine.extend({
     ]
   }
 });
+
+loadInitializers(Eng, modulePrefix);
+
+export default Eng;

--- a/tests/dummy/lib/ember-blog/addon/initializers/ember-blog-initializer.js
+++ b/tests/dummy/lib/ember-blog/addon/initializers/ember-blog-initializer.js
@@ -1,0 +1,6 @@
+export default {
+  name: 'ember-blog-initializer',
+  initialize() {
+
+  }
+}

--- a/tests/dummy/lib/ember-blog/addon/instance-initializers/ember-blog-instance-initializer.js
+++ b/tests/dummy/lib/ember-blog/addon/instance-initializers/ember-blog-instance-initializer.js
@@ -1,0 +1,5 @@
+export default {
+  name: 'ember-blog-instance-initializer',
+  initialize() {
+  }
+}


### PR DESCRIPTION
This enables initializers and instance-initializers inside engines.

The only change necessary to get instance-initializers running is altering the canonical addon/engine.js to invoke ember-load-initializers (which is analogous to what happens in app/app.js).

Getting the initializers running required an extention to the Engine class. Applications run them when they're told to boot, but no equivalent step happens for child engines, so instead we run them the first time we build an engine instance.