### PR TITLE
Fix npm install for local development

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,6 @@ before_install:
 
 install:
   - npm install -g bower
-  - npm run prepublish
   - npm install
   - bower install
 

--- a/bin/install-test-addons.sh
+++ b/bin/install-test-addons.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-mkdir -p node_modules
-
 rm -rf node_modules/common-components
 ln -s ../tests/dummy/lib/common-components node_modules/common-components
 

--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.2",
     "ember-ajax": "0.7.1",
-    "ember-blog": "*",
-    "ember-chat": "*",
+    "ember-blog": "file:./tests/dummy/lib/ember-blog",
+    "ember-chat": "file:./tests/dummy/lib/ember-chat",
     "ember-cli": "2.5.0",
     "ember-cli-app-version": "^1.0.0",
     "ember-cli-dependency-checker": "^1.2.0",

--- a/tests/dummy/lib/common-components/package.json
+++ b/tests/dummy/lib/common-components/package.json
@@ -1,5 +1,6 @@
 {
   "name": "common-components",
+  "version": "0.0.0",
   "keywords": [
     "ember-addon"
   ],

--- a/tests/dummy/lib/ember-chat/package.json
+++ b/tests/dummy/lib/ember-chat/package.json
@@ -7,6 +7,6 @@
   ],
   "dependencies": {
     "ember-cli-htmlbars": "*",
-    "common-components": "*"
+    "common-components": "file:../common-components"
   }
 }


### PR DESCRIPTION
Addressing #94.

Essentially, this tells NPM to install the addons from the local file system. We want to keep the `prepublish` script however, so that the addons still get symlinked to make changes appear more easily.