### PR TITLE
Routeable engine instances should be destroyed

### DIFF
--- a/addon/-private/router-ext.js
+++ b/addon/-private/router-ext.js
@@ -119,5 +119,18 @@ EmberRouter.reopen({
 
       return handler;
     };
+  },
+
+  /**
+    @private
+  */
+  willDestroy() {
+    this._super(...arguments);
+    let instances = this._engineInstances;
+    for (let name in instances) {
+      for (let id in instances[name]) {
+        Ember.run(instances[name][id], 'destroy');
+      }
+    }
   }
 });

--- a/tests/acceptance/teardown-test.js
+++ b/tests/acceptance/teardown-test.js
@@ -1,0 +1,21 @@
+import { module, test } from 'qunit';
+import startApp from '../helpers/start-app';
+import destroyApp from '../helpers/destroy-app';
+
+module('Acceptance | teardown test');
+
+test('routeable engines clean up their container state', function(assert) {
+  let service;
+  assert.expect(2);
+  this.application = startApp();
+
+  visit('/routable-engine-demo/blog/new');
+
+  andThen(() => {
+    assert.equal(currentURL(), '/routable-engine-demo/blog/new');
+    service = this.application.__container__.lookup('service:store').__exampleServiceForTesting;
+    destroyApp(this.application);
+    assert.ok(service.isDestroyed, 'service got destroyed');
+  });
+
+});

--- a/tests/dummy/lib/ember-blog/addon/routes/application.js
+++ b/tests/dummy/lib/ember-blog/addon/routes/application.js
@@ -1,7 +1,13 @@
 import Ember from 'ember';
 
 export default Ember.Route.extend({
+  exampleService: Ember.inject.service(),
+
   model() {
+    // cause a service to be instantiated, so that our tests can
+    // confirm that it gets cleaned up
+    this.get('exampleService');
+
     console.log('ember-chat.application route model hook');
     return {
       name: 'Derek Zoolander'

--- a/tests/dummy/lib/ember-blog/addon/services/example-service.js
+++ b/tests/dummy/lib/ember-blog/addon/services/example-service.js
@@ -1,0 +1,9 @@
+import Ember from 'ember';
+
+export default Ember.Service.extend({
+  dataStore: Ember.inject.service(),
+  init() {
+    // The store is provided by the containing application, so it's a convenient rendezvous point for our tests to be able to observe this instance.
+    this.get('dataStore').__exampleServiceForTesting = this;
+  }
+});


### PR DESCRIPTION
This change causes routeable engine instances and everything in their containers to be properly destroyed when an app is destroyed.

The routeless ones are also missing this feature, but I will file a separate issue for that, since I'm less clear on the right way to fix it.