### PR TITLE
Remove duplicate addRouteForEngine call

### DIFF
--- a/addon/-private/router-dsl-ext.js
+++ b/addon/-private/router-dsl-ext.js
@@ -44,8 +44,6 @@ EmberRouterDSL.prototype.mount = function(_name, _options) {
   let localFullName = 'application';
   let routeInfo = assign({ localFullName }, engineInfo);
 
-  this.options.addRouteForEngine(fullName, routeInfo);
-
   this.push(path, fullName, callback);
 };
 


### PR DESCRIPTION
`addRouteForEngine` is called inside `EmberRouterDSL.mount`, before `EmberRouterDSL.push` is called. `push` also calls addRouteForEngine, so it seems that it doesn't need to be done twice.