### PR TITLE
fix for mounting engines within an engine

### DIFF
--- a/addon/-private/router-dsl-ext.js
+++ b/addon/-private/router-dsl-ext.js
@@ -33,12 +33,23 @@ EmberRouterDSL.prototype.mount = function(_name, _options) {
 
   let callback;
   if (engineRouteMap) {
+    let shouldResetEngineInfo = false;
+    let oldEngineInfo = this.options.engineInfo;
+    if (oldEngineInfo) {
+      shouldResetEngineInfo = true;
+      this.options.engineInfo = engineInfo;
+    }
+
     let optionsForChild = assign({ engineInfo }, this.options);
     let childDSL = new EmberRouterDSL(fullName, optionsForChild);
 
     engineRouteMap.call(childDSL);
 
     callback = childDSL.generate();
+
+    if (shouldResetEngineInfo) {
+      this.options.engineInfo = oldEngineInfo;
+    }
   }
 
   let localFullName = 'application';


### PR DESCRIPTION
With these changes we can do some enginception, or mounting an engine within an engine.

Not sure if this is the right place to put the fix, but when processing an engine's routes, calling mount again breaks because this.options.engineInfo points to the outer engine's engineInfo.