### PR TITLE
Remove engines feature flag for v0.2 branch.

### DIFF
--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -10,7 +10,7 @@ module.exports = function(environment) {
       FEATURES: {
         // Here you can enable experimental features on an ember canary build
         // e.g. 'with-controller': true
-        'ember-application-engines': true
+        // 'ember-application-engines': true
       }
     },
 


### PR DESCRIPTION
The v0.2 branch will be maintained for use with production builds
of Ember v2.6. Since feature flags are only allowed in canary
builds, we should remove it for this branch in order to avoid
ember-cli warnings.