### PR TITLE
streams dependency was moved into ember-htmlbars

### DIFF
--- a/addon/-private/keywords/mount.js
+++ b/addon/-private/keywords/mount.js
@@ -2,7 +2,7 @@ import Ember from "ember";
 import emberRequire from '../ext-require';
 
 // const internal = emberRequire('htmlbars-runtime').internal;
-const read = emberRequire('ember-metal/streams/utils', 'read');
+const read = emberRequire('ember-htmlbars/streams/utils', 'read');
 const registerKeyword = emberRequire('ember-htmlbars/keywords', 'registerKeyword');
 // const legacyViewKeyword = emberRequire('ember-htmlbars/keywords/view');
 const ViewNodeManager = emberRequire('ember-htmlbars/node-managers/view-node-manager');


### PR DESCRIPTION
This fixes the issue mentioned by @thousand [here][1]. Maybe it'd be a good idea to refer to a specific Ember.js commit when installing Ember?

[1]: https://github.com/dgeb/ember-engines/issues/126#issuecomment-224102436