### PR TITLE
Support engine configuration settings.

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,14 +94,32 @@ module.exports = EngineAddon.extend({
 });
 ```
 
+Within your engine's `config` directory, create a new `environment.js` file:
+
+```js
+/*jshint node:true*/
+'use strict';
+
+module.exports = function(environment) {
+  var ENV = {
+    modulePrefix: 'ember-blog',
+    environment: environment
+  }
+
+  return ENV;
+};
+```
+
 Within your engine's `addon` directory, add a new `engine.js` file:
 
 ```js
 import Engine from 'ember-engines/engine';
-import Resolver from 'ember-engines/resolver';
+import Resolver from 'ember-engines/resolver'; // <=== IMPORTANT - custom resolver!!!
 import loadInitializers from 'ember-load-initializers';
+import config from './config/environment';
 
-const modulePrefix = 'ember-blog';
+const { modulePrefix } = config;
+
 const Eng = Engine.extend({
   modulePrefix,
   Resolver
@@ -110,11 +128,10 @@ const Eng = Engine.extend({
 loadInitializers(Eng, modulePrefix);
 
 export default Eng;
-
 ```
 
-It's important to define a `modulePrefix` that will be used to resolve your
-engine and its constituent modules.
+It's important that `modulePrefix` be set in `config/environment.js` so that
+it can be referenced in `addon/engine.js`.
 
 ### Routable Engines
 
@@ -155,18 +172,24 @@ For example, the following engine requires a `store` service from its parent:
 ```js
 import Engine from 'ember-engines/engine';
 import Resolver from 'ember-engines/resolver';
+import loadInitializers from 'ember-load-initializers';
+import config from './config/environment';
 
-export default Engine.extend({
-  modulePrefix: 'ember-blog',
+const { modulePrefix } = config;
 
+const Eng = Engine.extend({
+  modulePrefix,
   Resolver,
-
   dependencies: {
     services: [
       'store'
     ]
   }
 });
+
+loadInitializers(Eng, modulePrefix);
+
+export default Eng;
 ```
 
 Currently, only services and route paths (see below) can be shared across the
@@ -199,8 +222,8 @@ located via a route path:
 ```js
 // dummy/app/app.js
 const App = Ember.Application.extend({
-  modulePrefix: config.modulePrefix,
-  podModulePrefix: config.podModulePrefix,
+  modulePrefix,
+  podModulePrefix,
   Resolver,
 
   engines: {
@@ -215,6 +238,7 @@ const App = Ember.Application.extend({
   }
 });
 ```
+
 You can then use those external routes either programmatically or within a
 template like so:
 
@@ -249,21 +273,21 @@ provided in the `ember-engines/resolver` module. For example:
 
 ```js
 import Ember from 'ember';
-import Resolver from 'ember-engines/resolver';
+import Resolver from 'ember-engines/resolver'; // <=== IMPORTANT - custom resolver!!!
 import loadInitializers from 'ember/load-initializers';
 import config from './config/environment';
 
-let App;
-
 Ember.MODEL_FACTORY_INJECTIONS = true;
 
-App = Ember.Application.extend({
-  modulePrefix: config.modulePrefix,
-  podModulePrefix: config.podModulePrefix,
+const { modulePrefix, podModulePrefix } = config;
+
+const App = Ember.Application.extend({
+  modulePrefix,
+  podModulePrefix,
   Resolver
 });
 
-loadInitializers(App, config.modulePrefix);
+loadInitializers(App, modulePrefix);
 
 export default App;
 ```
@@ -369,13 +393,13 @@ import Resolver from 'ember-engines/resolver';
 import loadInitializers from 'ember/load-initializers';
 import config from './config/environment';
 
-let App;
-
 Ember.MODEL_FACTORY_INJECTIONS = true;
 
-App = Ember.Application.extend({
-  modulePrefix: config.modulePrefix,
-  podModulePrefix: config.podModulePrefix,
+const { modulePrefix, podModulePrefix } = config;
+
+const App = Ember.Application.extend({
+  modulePrefix,
+  podModulePrefix,
   Resolver,
 
   engines: {
@@ -390,7 +414,7 @@ App = Ember.Application.extend({
   }
 });
 
-loadInitializers(App, config.modulePrefix);
+loadInitializers(App, modulePrefix);
 
 export default App;
 ```

--- a/blueprints/in-repo-engine/index.js
+++ b/blueprints/in-repo-engine/index.js
@@ -3,9 +3,22 @@
 var path = require('path');
 var InRepoAddon = require('ember-cli/blueprints/in-repo-addon/index');
 var Route = require('ember-cli/blueprints/route/index');
+var stringUtil = require('ember-cli-string-utils');
 
 module.exports = {
   description: 'Creates an Engine within the current repository.',
+
+  locals: function(options) {
+    var entity    = options.entity;
+    var rawName   = entity.name;
+    var name      = stringUtil.dasherize(rawName);
+    var namespace = stringUtil.classify(rawName);
+
+    return {
+      name: name,
+      modulePrefix: name
+    };
+  },
 
   availableOptions: [
     {

--- a/blueprints/in-repo-engine/routable-files/lib/__name__/addon/engine.js
+++ b/blueprints/in-repo-engine/routable-files/lib/__name__/addon/engine.js
@@ -1,8 +1,10 @@
 import Engine from 'ember-engines/engine';
 import Resolver from 'ember-engines/resolver';
 import loadInitializers from 'ember-load-initializers';
+import config from './config/environment';
 
-const modulePrefix = 'ember-blog';
+const { modulePrefix } = config;
+
 const Eng = Engine.extend({
   modulePrefix,
   Resolver

--- a/blueprints/in-repo-engine/routable-files/lib/__name__/config/environment.js
+++ b/blueprints/in-repo-engine/routable-files/lib/__name__/config/environment.js
@@ -1,0 +1,11 @@
+/*jshint node:true*/
+'use strict';
+
+module.exports = function(environment) {
+  var ENV = {
+    modulePrefix: '<%= modulePrefix %>',
+    environment: environment
+  }
+
+  return ENV;
+};

--- a/blueprints/in-repo-engine/routeless-files/lib/__name__/addon/engine.js
+++ b/blueprints/in-repo-engine/routeless-files/lib/__name__/addon/engine.js
@@ -1,8 +1,10 @@
 import Engine from 'ember-engines/engine';
 import Resolver from 'ember-engines/resolver';
 import loadInitializers from 'ember-load-initializers';
+import config from './config/environment';
 
-const modulePrefix = 'ember-blog';
+const { modulePrefix } = config;
+
 const Eng = Engine.extend({
   modulePrefix,
   Resolver

--- a/blueprints/in-repo-engine/routeless-files/lib/__name__/config/environment.js
+++ b/blueprints/in-repo-engine/routeless-files/lib/__name__/config/environment.js
@@ -1,0 +1,11 @@
+/*jshint node:true*/
+'use strict';
+
+module.exports = function(environment) {
+  var ENV = {
+    modulePrefix: '<%= modulePrefix %>',
+    environment: environment
+  }
+
+  return ENV;
+};

--- a/lib/engine-addon.js
+++ b/lib/engine-addon.js
@@ -1,5 +1,10 @@
 var Funnel = require('broccoli-funnel');
+var merge = require('lodash/merge');
 var mergeTrees = require('broccoli-merge-trees');
+var existsSync = require('exists-sync');
+var fs = require('fs');
+var path = require('path');
+var writeFile = require('broccoli-file-creator');
 
 module.exports = {
   extend: function(options) {
@@ -7,6 +12,107 @@ module.exports = {
       throw new Error('Do not provide a custom `options.treeFor` with `EngineAddon.extend(options)`.');
     }
 
+    /**
+      Returns configuration settings that will augment the application's
+      configuration settings.
+
+      By default, engines return `null`, and maintain their own separate
+      configuration settings which are retrieved via `engineConfig()`.
+
+      @public
+      @method config
+      @param {String} env Name of current environment (e.g. "developement")
+      @param {Object} baseConfig Initial application configuration
+      @return {Object} Configuration object to be merged with application configuration.
+    */
+    options.config = function(env, baseConfig) {
+      return null;
+    };
+
+    /**
+      Returns an engine's configuration settings, to be used exclusively by the
+      engine.
+
+      By default, this method simply reads the configuration settings from
+      an engine's `config/environment.js`.
+
+      @public
+      @method engineConfig
+      @param {String} env Name of current environment (e.g. "developement")
+      @param {Object} baseConfig Initial engine configuration
+      @return {Object} Configuration object that will be provided to the engine.
+    */
+    options.engineConfig = function(env, baseConfig) {
+      var configPath = path.join(this.root, 'config', 'environment.js');
+
+      if (existsSync(configPath)) {
+        var configGenerator = require(configPath);
+
+        var engineConfig = configGenerator(env, baseConfig);
+
+        var addonsConfig = this.getAddonsConfig(env, engineConfig);
+
+        return merge(addonsConfig, engineConfig);
+      } else {
+        return this.getAddonsConfig(env, {});
+      }
+    };
+
+    /**
+      Returns the addons' configuration.
+
+      @private
+      @method getAddonsConfig
+      @param  {String} env           Environment name
+      @param  {Object} engineConfig  Engine configuration
+      @return {Object}               Merged configuration of all addons
+     */
+    options.getAddonsConfig = function(env, engineConfig) {
+      this.initializeAddons();
+
+      var initialConfig = merge({}, engineConfig);
+
+      return this.addons.reduce(function(config, addon) {
+        if (addon.config) {
+          merge(config, addon.config(env, config));
+        }
+
+        return config;
+      }, initialConfig);
+    };
+
+    /**
+      Overrides the content provided for the `head` section to include
+      the engine's configuration settings as a meta tag.
+
+      @public
+      @method contentFor
+      @param type
+      @param config
+    */
+    options.contentFor = function(type, config) {
+      if (type === 'head') {
+        var engineConfig = this.engineConfig(config.environment, {});
+
+        var content = '<meta name="' + options.name + '/config/environment" ' +
+                      'content="' + escape(JSON.stringify(engineConfig)) + '" />';
+
+        return content;
+      }
+
+      return '';
+    };
+
+    /**
+      Returns a given type of tree (if present), merged with the
+      application tree. For each of the trees available using this
+      method, you can also use a direct method called `treeFor[Type]` (eg. `treeForApp`).
+
+      @public
+      @method treeFor
+      @param {String} name
+      @return {Tree}
+    */
     options.treeFor = function treeFor(name) {
       var tree, trees;
 
@@ -18,13 +124,25 @@ module.exports = {
         trees = this.eachAddonInvoke('treeFor', [name]);
 
         if (name === 'addon') {
-          var appTree = mergeTrees(this.eachAddonInvoke('treeFor', ['app']), {
+          var treesForApp = this.eachAddonInvoke('treeFor', ['app']);
+
+          // Include a module that reads the engine's configuration from its
+          // meta tag and exports its contents.
+          var configTemplatePath = path.join(__dirname, '/engine-config-from-meta.js');
+          var configTemplate = fs.readFileSync(configTemplatePath, { encoding: 'utf8' });
+          var configContents = configTemplate.replace('{{MODULE_PREFIX}}', options.name);
+          var configTree = writeFile('/config/environment.js', configContents);
+          treesForApp.push(configTree);
+
+          var appTree = mergeTrees(treesForApp, {
             overwrite: true,
             annotation: 'Engine#treeFor (' + options.name + ' - ' + name + ')'
           });
+
           var funneledAppTree = new Funnel(appTree, {
             destDir: 'modules/' + options.name
           });
+
           trees.push(funneledAppTree);
         }
       }

--- a/lib/engine-config-from-meta.js
+++ b/lib/engine-config-from-meta.js
@@ -1,0 +1,14 @@
+import Ember from 'ember';
+
+var config;
+
+try {
+  var metaName = '{{MODULE_PREFIX}}/config/environment';
+  var rawConfig = Ember.$('meta[name="' + metaName + '"]').attr('content');
+  config = JSON.parse(unescape(rawConfig));
+}
+catch(err) {
+  throw new Error('Could not read config from meta tag with name "' + metaName + '".');
+}
+
+export default config;

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "ember-cli": "2.5.0",
     "ember-cli-app-version": "^1.0.0",
     "ember-cli-dependency-checker": "^1.2.0",
-    "ember-cli-htmlbars": "^1.0.3",
     "ember-cli-htmlbars-inline-precompile": "^0.3.1",
     "ember-cli-inject-live-reload": "^1.4.0",
     "ember-cli-jshint": "^1.0.0",
@@ -52,10 +51,14 @@
     "ember-addon"
   ],
   "dependencies": {
+    "broccoli-file-creator": "^1.1.0",
     "broccoli-funnel": "^1.0.0",
     "broccoli-merge-trees": "^1.0.0",
-    "ember-cli-htmlbars": "^1.0.1",
-    "ember-cli-babel": "^5.1.5"
+    "ember-cli-babel": "^5.1.5",
+    "ember-cli-htmlbars": "^1.0.3",
+    "ember-cli-string-utils": "^1.0.0",
+    "exists-sync": "0.0.3",
+    "lodash": "^4.12.0"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"

--- a/tests/dummy/app/app.js
+++ b/tests/dummy/app/app.js
@@ -3,13 +3,13 @@ import Resolver from 'ember-engines/resolver';
 import loadInitializers from 'ember-load-initializers';
 import config from './config/environment';
 
-let App;
-
 Ember.MODEL_FACTORY_INJECTIONS = true;
 
-App = Ember.Application.extend({
-  modulePrefix: config.modulePrefix,
-  podModulePrefix: config.podModulePrefix,
+const { modulePrefix, podModulePrefix } = config;
+
+const App = Ember.Application.extend({
+  modulePrefix,
+  podModulePrefix,
   Resolver,
 
   engines: {
@@ -33,6 +33,6 @@ App = Ember.Application.extend({
   }
 });
 
-loadInitializers(App, config.modulePrefix);
+loadInitializers(App, modulePrefix);
 
 export default App;

--- a/tests/dummy/lib/ember-blog/addon/engine.js
+++ b/tests/dummy/lib/ember-blog/addon/engine.js
@@ -1,15 +1,13 @@
 import Engine from 'ember-engines/engine';
 import Resolver from 'ember-engines/resolver';
 import loadInitializers from 'ember-load-initializers';
+import config from './config/environment';
 
-let Eng;
+const { modulePrefix } = config;
 
-const modulePrefix = 'ember-blog';
-
-Eng = Engine.extend({
+const Eng = Engine.extend({
   modulePrefix,
   Resolver,
-
   dependencies: {
     services: [
       'data-store'

--- a/tests/dummy/lib/ember-blog/config/environment.js
+++ b/tests/dummy/lib/ember-blog/config/environment.js
@@ -1,0 +1,11 @@
+/*jshint node:true*/
+'use strict';
+
+module.exports = function(environment) {
+  var ENV = {
+    modulePrefix: 'ember-blog',
+    environment: environment
+  }
+
+  return ENV;
+};

--- a/tests/dummy/lib/ember-chat/addon/engine.js
+++ b/tests/dummy/lib/ember-chat/addon/engine.js
@@ -1,14 +1,20 @@
 import Engine from 'ember-engines/engine';
 import Resolver from 'ember-engines/resolver';
+import loadInitializers from 'ember-load-initializers';
+import config from './config/environment';
 
-export default Engine.extend({
-  modulePrefix: 'ember-chat',
+const { modulePrefix } = config;
 
+const Eng = Engine.extend({
+  modulePrefix,
   Resolver,
-
   dependencies: {
     services: [
       'store'
     ]
   }
 });
+
+loadInitializers(Eng, modulePrefix);
+
+export default Eng;

--- a/tests/dummy/lib/ember-chat/config/environment.js
+++ b/tests/dummy/lib/ember-chat/config/environment.js
@@ -1,0 +1,11 @@
+/*jshint node:true*/
+'use strict';
+
+module.exports = function(environment) {
+  var ENV = {
+    modulePrefix: 'ember-chat',
+    environment: environment
+  }
+
+  return ENV;
+};


### PR DESCRIPTION
Engines can now store their own configuration settings in 
`config/environment.js`. 

Adjust examples to import this module and use it to define 
`modulePrefix`.