### PR TITLE
Refactoring mount keyword to properly build child environment in render flows.

### DIFF
--- a/addon/-private/keywords/mount.js
+++ b/addon/-private/keywords/mount.js
@@ -64,7 +64,7 @@ registerKeyword('mount', {
     }
   },
 
-  setupState(prevState, env, scope, params, hash) {
+  setupState(prevState, env, scope, params /*, hash */) {
     let name = params[0];
 
     assert(

--- a/addon/-private/keywords/mount.js
+++ b/addon/-private/keywords/mount.js
@@ -114,7 +114,7 @@ registerKeyword('mount', {
     // var name = params[0];
     // var context = params[1];
 
-    var owner = env.owner;
+    // var owner = env.owner;
 
     // The render keyword presumes it can work without a router. This is really
     // only to satisfy the test:
@@ -122,7 +122,7 @@ registerKeyword('mount', {
     //     {{view}} should not override class bindings defined on a child view"
     //
 
-    let engineName = params[0];
+    // let engineName = params[0];
 
     let engineInstance = getEngineFromState(state); // owner.buildChildEngineInstance(engineName);
     if (!engineInstance._booted) {

--- a/tests/acceptance/routeless-engine-demo-test.js
+++ b/tests/acceptance/routeless-engine-demo-test.js
@@ -25,4 +25,4 @@ test('can rerender a component in a routeless engine', function(assert) {
       assert.equal($clickCount.text().trim(), '1');
     });
   });
-})
+});

--- a/tests/acceptance/routeless-engine-demo-test.js
+++ b/tests/acceptance/routeless-engine-demo-test.js
@@ -13,3 +13,16 @@ test('can invoke components directly in an engine and also that are dependencies
     assert.equal(this.application.$('.hola .greeting').text().trim(), 'Hola');
   });
 });
+
+test('can rerender a component in a routeless engine', function(assert) {
+  visit('/routeless-engine-demo');
+
+  andThen(() => {
+    let $clickCount = find('.click-count');
+    assert.equal($clickCount.text().trim(), '0');
+    click('button.clicker');
+    andThen(() => {
+      assert.equal($clickCount.text().trim(), '1');
+    });
+  });
+})

--- a/tests/dummy/lib/ember-chat/addon/components/hello-world.js
+++ b/tests/dummy/lib/ember-chat/addon/components/hello-world.js
@@ -8,11 +8,16 @@ export default Ember.Component.extend({
 
   init() {
     this._super(...arguments);
+    this.set('clickCount', 0);
 
     console.log('hello-world.init');
   },
 
-  click() {
-    console.log('hello-world click');
+  actions: {
+    click() {
+      console.log('hello-world click');
+      this.incrementProperty('clickCount');
+    }
   }
+
 });

--- a/tests/dummy/lib/ember-chat/addon/templates/components/hello-world.hbs
+++ b/tests/dummy/lib/ember-chat/addon/templates/components/hello-world.hbs
@@ -1,1 +1,3 @@
 <span class="greeting">Hello</span> from {{name}}!
+<button class="clicker" {{action "click"}}>Clicker</button>
+<span class="click-count">{{clickCount}}</span>

--- a/tests/dummy/lib/ember-chat/addon/views/application.js
+++ b/tests/dummy/lib/ember-chat/addon/views/application.js
@@ -9,5 +9,9 @@ export default Ember.Component.extend({
   willRender() {
     console.log('ChatEngine.ApplicationView - willRender');
     this._super(...arguments);
+  },
+
+  click() {
+    console.log('what?');
   }
 });


### PR DESCRIPTION
This is at least a proof of concept to address the problem identified in #126 to the best of my ability. Adding a prop onto `state` feels ugly to me, so please advise if there's a better place to put this functionality.

Steps taken: 
* Break engine instance setup into separate function
* Moved assertions to match where engine will be first instantiated
* Attach `engineInstance` to `state` where it can be re-referenced in subsequent renders of child nodes
* generate render environment in `childEnv` based on `engineInstance`'s `application` view and template.