### PR TITLE
Ignore node_modules from test engines/addons

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@
 /libpeerconnection.log
 npm-debug.log
 testem.log
+tests/dummy/lib/**/node_modules


### PR DESCRIPTION
running 
```sh
./bin/install-test-addons.sh
```
leaves the user in a dirty git state. Because this is in the prepublish hook, it can happen when doing things like `npm link`.

