### PR TITLE
Allow custom engine config locations via `engineConfigPath`.

### DIFF
--- a/lib/engine-addon.js
+++ b/lib/engine-addon.js
@@ -45,8 +45,8 @@ module.exports = {
     options.engineConfig = function(env, baseConfig) {
       var configPath = 'config';
 
-      if (this.pkg['ember-addon'] && this.pkg['ember-addon']['configPath']) {
-        configPath = this.pkg['ember-addon']['configPath'];
+      if (this.pkg['ember-addon'] && this.pkg['ember-addon']['engineConfigPath']) {
+        configPath = this.pkg['ember-addon']['engineConfigPath'];
       }
 
       configPath = path.join(this.root, configPath, 'environment.js');

--- a/tests/dummy/lib/ember-blog/package.json
+++ b/tests/dummy/lib/ember-blog/package.json
@@ -6,7 +6,7 @@
     "ember-engine"
   ],
   "ember-addon": {
-    "configPath": "ember-config"
+    "engineConfigPath": "ember-config"
   },
   "dependencies": {
     "ember-cli-htmlbars": "*"


### PR DESCRIPTION
Instead of overloading the usage of `configPath`, engines need their
own unique setting to specify their configuration file path.

[Fixes #149]