### PR TITLE
Document routing concerns for lazy engines

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,38 @@ this.transitionToExternal('settings');
 
 For further documentation on this subject, view the [Engine Linking RFC](https://github.com/emberjs/rfcs/pull/122).
 
+### Lazy-Loading Routing Considerations
+
+When routing into an Engine that is lazily loaded there are some special considerations and subtle differences from how routing works in a normal Ember application.
+
+#### Serialization of URLs
+
+Since the links to your Engine are constructed before the Engine itself is loaded, you need to make sure the application has the necessary code to serialize data into the URLs. To that end, you need to replace any [`Route#serialize`](http://emberjs.com/api/classes/Ember.Route.html#method_serialize) functions with route serializers, as defined in [the Route Serializers RFC](https://github.com/emberjs/rfcs/blob/master/text/0120-route-serializers.md).
+
+For example, if you had a `Post` route defined like so:
+
+```js
+export default Ember.Route.extend({
+  serialize(model) {
+    return { post_id: model.id };
+  }
+});
+```
+
+You would need to remove that function and inline it into your `routes.js` map, which is loaded pre-emptively with the application:
+
+```js
+function serializePost(model) {
+  return { post_id: model.id };
+}
+
+export default buildRoutes(function() {
+  this.route('post', { serialize: serializePost });
+});
+```
+
+Note that route serializers are unique to Engines and won't work in normal applications. In a normal Ember application you should continue to use `Route#serialize`.
+
 ### Accessing Engine Configuration Settings
 
 As in an application, you can provide configuration settings for your

--- a/README.md
+++ b/README.md
@@ -286,6 +286,10 @@ export default buildRoutes(function() {
 
 Note that route serializers are unique to Engines and won't work in normal applications. In a normal Ember application you should continue to use `Route#serialize`.
 
+#### Loading / Error Substates
+
+The loading and error substates work in a similar fashion to [substates in a normal Ember app](https://guides.emberjs.com/v2.6.0/routing/loading-and-error-substates/). The only difference is that lazily loaded Engines will enter a loading state while the assets for the Engine are loaded and can enter an error state when an asset fails to load.
+
 ### Accessing Engine Configuration Settings
 
 As in an application, you can provide configuration settings for your


### PR DESCRIPTION
- Document route-serializer usage in ember-engines and how it differs from behavior outside of engines.
- Document change in loading behavior for failed transitions when crossing an engine boundary.