### PR TITLE
Add failing integration test for v0.2

### DIFF
--- a/tests/dummy/app/templates/components/app-component.hbs
+++ b/tests/dummy/app/templates/components/app-component.hbs
@@ -1,0 +1,1 @@
+<p>I'm a component!</p>

--- a/tests/integration/components/app-component-test.js
+++ b/tests/integration/components/app-component-test.js
@@ -1,0 +1,11 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('app-component', 'Integration | Component | app-component', {
+  integration: true
+});
+
+test('it renders', function(assert) {
+  this.render(hbs`{{#app-component}}{{/app-component}}`);
+  assert.equal(this.$().text().trim(), 'I\'m a component!');
+});


### PR DESCRIPTION
With new versions of ember-test-helpers, integration tests for components invoked in block-form fail in apps using `ember-engines`. This PR has a failing test to debug against.

The failures start with @rwjblue's recent changes to use `outlet`s in integration tests ([ref](https://github.com/switchfly/ember-test-helpers/pull/158)). So I am almost positive the issue lies somewhere in [the `outlet` keyword modifications](https://github.com/dgeb/ember-engines/blob/v0.2/addon/-private/keywords/outlet.js).

cc @tjni