### PR TITLE
Test: Query parameters are not rehydrated

### DIFF
--- a/tests/acceptance/routeable-engine-demo-test.js
+++ b/tests/acceptance/routeable-engine-demo-test.js
@@ -30,6 +30,20 @@ test('can deserialize a route\'s params', function(assert) {
   });
 });
 
+test('can restore unspecified query parameters', function(assert) {
+  assert.expect(2);
+
+  visit('/routable-engine-demo/blog/post/1?lang=English');
+  click('.routable-post-comments-link');
+  click('.back-to-post-link');
+
+  andThen(() => {
+    assert.equal(currentURL(), '/routable-engine-demo/blog/post/1?lang=English');
+
+    assert.equal(this.application.$('p.language').text().trim(), 'English');
+  });
+});
+
 test('a route can lookup another route\'s model', function(assert) {
   assert.expect(2);
 

--- a/tests/dummy/lib/ember-blog/addon/controllers/post.js
+++ b/tests/dummy/lib/ember-blog/addon/controllers/post.js
@@ -1,0 +1,5 @@
+import Ember from 'ember';
+
+export default Ember.Controller.extend({
+  queryParams: ['lang']
+});

--- a/tests/dummy/lib/ember-blog/addon/templates/post.hbs
+++ b/tests/dummy/lib/ember-blog/addon/templates/post.hbs
@@ -2,6 +2,8 @@
 
 <p class="author">{{model.user.name}}</p>
 
+<p class="language">{{lang}}</p>
+
 {{#link-to "post.comments" 1 class="routable-post-comments-link"}}Comments{{/link-to}}
 
 {{outlet}}

--- a/tests/dummy/lib/ember-blog/addon/templates/post/comments.hbs
+++ b/tests/dummy/lib/ember-blog/addon/templates/post/comments.hbs
@@ -1,1 +1,5 @@
 <h4 class="comments">Comments for {{model.title}}</h4>
+
+{{#link-to "post" class="back-to-post-link"}}
+  Back to Post
+{{/link-to}}


### PR DESCRIPTION
Same test, which was pushed in v0.2 branch. The actual fix is in the ember codebase.