### PR TITLE
Generate engine config in separate method

### DIFF
--- a/lib/engine-addon.js
+++ b/lib/engine-addon.js
@@ -110,6 +110,20 @@ module.exports = {
     };
 
     /**
+      Returns the contents of the module to be used for accessing the Engine's
+      config.
+
+      @public
+      @method getEngineConfigContents
+      @return {String}
+    */
+    options.getEngineConfigContents = options.getEngineConfigContents || function() {
+      var configTemplatePath = path.join(__dirname, '/engine-config-from-meta.js');
+      var configTemplate = fs.readFileSync(configTemplatePath, { encoding: 'utf8' });
+      return configTemplate.replace('{{MODULE_PREFIX}}', options.name);
+    };
+
+    /**
       Returns a given type of tree (if present), merged with the
       application tree. For each of the trees available using this
       method, you can also use a direct method called `treeFor[Type]` (eg. `treeForApp`).
@@ -134,9 +148,7 @@ module.exports = {
 
           // Include a module that reads the engine's configuration from its
           // meta tag and exports its contents.
-          var configTemplatePath = path.join(__dirname, '/engine-config-from-meta.js');
-          var configTemplate = fs.readFileSync(configTemplatePath, { encoding: 'utf8' });
-          var configContents = configTemplate.replace('{{MODULE_PREFIX}}', options.name);
+          var configContents = this.getEngineConfigContents();
           var configTree = writeFile('/config/environment.js', configContents);
           treesForApp.push(configTree);
 

--- a/lib/engine-config-from-meta.js
+++ b/lib/engine-config-from-meta.js
@@ -1,14 +1,12 @@
-import Ember from 'ember';
-
 var config;
 
 try {
   var metaName = '{{MODULE_PREFIX}}/config/environment';
-  var rawConfig = Ember.$('meta[name="' + metaName + '"]').attr('content');
+  var rawConfig = document.querySelector('meta[name="' + metaName + '"]').getAttribute('content');
   config = JSON.parse(unescape(rawConfig));
 }
 catch(err) {
-  throw new Error('Could not read config from meta tag with name "' + metaName + '".');
+  throw new Error('Could not read config from meta tag with name "' + metaName + '" due to error: ' + err);
 }
 
 export default config;


### PR DESCRIPTION
An attempt at addressing #164. This provides a hook which can be overriden to return a version of the config module that works in non-browser environments.

I'm open to other options, but this is the best one I could come up with currently.