### PR TITLE
Ember 2.7 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ cache:
 
 env:
   - EMBER_TRY_SCENARIO=ember-2.6
+  - EMBER_TRY_SCENARIO=ember-2.7
 
 matrix:
   fast_finish: true

--- a/addon/-private/engine-ext.js
+++ b/addon/-private/engine-ext.js
@@ -10,7 +10,6 @@ const P = emberRequire('container/registry', 'privatize');
 const topLevelViewTemplate = emberRequire('ember-htmlbars/templates/top-level-view');
 
 const {
-  OutletView,
   TextField,
   TextArea,
   Checkbox,
@@ -52,7 +51,6 @@ Engine.reopen({
 
       registry.register('template:-outlet', topLevelViewTemplate);
       registry.injection('route', '_topLevelViewTemplate', 'template:-outlet');
-      registry.register('view:-outlet', OutletView);
 
       //registry.register('-view-registry:main', { create() { return {}; } });
 

--- a/addon/-private/keywords/mount.js
+++ b/addon/-private/keywords/mount.js
@@ -1,7 +1,9 @@
 import Ember from "ember";
 import emberRequire from '../ext-require';
 
-const read = emberRequire('ember-metal/streams/utils', 'read');
+const read = Ember.__loader.registry['ember-htmlbars/streams/utils'] ?
+  emberRequire('ember-htmlbars/streams/utils', 'read') :
+  emberRequire('ember-metal/streams/utils', 'read');
 const registerKeyword = emberRequire('ember-htmlbars/keywords', 'registerKeyword');
 const ViewNodeManager = emberRequire('ember-htmlbars/node-managers/view-node-manager');
 const RenderEnv = emberRequire('ember-htmlbars/system/render-env');

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "ember-engines",
   "dependencies": {
-    "ember": "~2.6.0",
+    "ember": "~2.7.0",
     "ember-cli-shims": "0.1.1",
     "ember-cli-test-loader": "0.2.2",
     "ember-qunit-notifications": "0.1.0"

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -19,6 +19,17 @@ module.exports = {
       }
     },
     {
+      name: 'ember-2.7',
+      bower: {
+        dependencies: {
+          'ember': '~2.7.0'
+        },
+        resolutions: {
+          'ember': '~2.7.0'
+        }
+      }
+    },
+    {
       name: 'ember-release',
       bower: {
         dependencies: {


### PR DESCRIPTION
Attempting to get 2.7 compatibility. Would be nice to be able to upgrade before the flag is enabled in 2.8.