### PR TITLE
Add `lazyLoading` property to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,17 @@ export default Eng;
 It's important that `modulePrefix` be set in `config/environment.js` so that
 it can be referenced in `addon/engine.js`.
 
+### Lazy Loading Engines
+
+You must also declare in your Engine's `index.js` file whether or not the engine should be lazy loaded. Until lazy loading is supported, this should be set to `false`:
+```js
+var EngineAddon = require('ember-engines/lib/engine-addon');
+module.exports = EngineAddon.extend({
+  name: 'ember-blog',
+  lazyLoading: false
+});
+```
+
 ### Routable Engines
 
 Routable engines should declare their route map in a `routes.js` file.


### PR DESCRIPTION
Since not including this property has been deprecated.

We should also consider improving the blueprints to include this property out of the box.