### PR TITLE
Lazy Load Runtime

### DIFF
--- a/addon/-private/router-ext.js
+++ b/addon/-private/router-ext.js
@@ -1,0 +1,203 @@
+import Ember from 'ember';
+import emberRequire from './ext-require';
+
+const hasDefaultSerialize = emberRequire('ember-routing/system/route', 'hasDefaultSerialize');
+const EmptyObject = emberRequire('ember-metal/empty_object');
+
+const {
+  Logger: {
+    info
+  },
+  Router,
+  RSVP,
+  assert,
+  get,
+  getOwner
+} = Ember;
+
+Router.reopen({
+  assetLoader: Ember.inject.service(),
+
+  /**
+   * We skip doing default query params stuff when attempting to go to an
+   * Engine route.
+   *
+   * @override
+   */
+  _prepareQueryParams(routeName) {
+    if (this._engineInfoByRoute[routeName]) {
+      return;
+    }
+
+    return this._super(...arguments);
+  },
+
+  /**
+   * We override this to fetch assets when crossing into a lazy Engine for the
+   * first time. For other cases we do the normal thing.
+   *
+   * @override
+   */
+  _getHandlerFunction() {
+    let seen = new EmptyObject();
+    let owner = getOwner(this);
+
+    return (name) => {
+      let engineInfo = this._engineInfoByRoute[name];
+
+      if (engineInfo) {
+        return this._getEngineInstance(engineInfo).then((instance) => {
+          let handler = this._internalGetHandler(seen, name, engineInfo.localFullName, instance);
+
+          if (!hasDefaultSerialize(handler)) {
+            throw new Error('Defining a custom serialize method on an Engine route is not supported.');
+          }
+
+          return handler;
+        });
+      }
+
+      // If we don't cross into an Engine, then the routeName and localRouteName
+      // are the same.
+      return this._internalGetHandler(seen, name, name, owner);
+    };
+  },
+
+  /**
+   * This method is responsible for actually doing the lookup in getHandler.
+   * It is separate so that it can be used from different code paths.
+   *
+   * @private
+   * @method _internalGetHandler
+   * @param {Object} seen
+   * @param {String} routeName
+   * @param {String} localRouteName
+   * @param {Owner} routeOwner
+   * @return {Route} handler
+   */
+  _internalGetHandler(seen, routeName, localRouteName, routeOwner) {
+    const fullRouteName = 'route:' + localRouteName;
+    let handler = routeOwner.lookup(fullRouteName);
+
+    if (seen[routeName] && handler) {
+      return handler;
+    }
+
+    seen[routeName] = true;
+
+    if (!handler) {
+      const DefaultRoute = routeOwner._lookupFactory('route:basic');
+
+      routeOwner.register(fullRouteName, DefaultRoute.extend());
+      handler = routeOwner.lookup(fullRouteName);
+
+      if (get(this, 'namespace.LOG_ACTIVE_GENERATION')) {
+        info(`generated -> ${fullRouteName}`, { fullName: fullRouteName });
+      }
+    }
+
+    handler.routeName = localRouteName;
+
+    return handler;
+  },
+
+  /**
+   * Checks the owner to see if it has a registration for an Engine. This is a
+   * proxy to tell if an Engine class is loaded or not.
+   *
+   * @private
+   * @method _engineIsLoaded
+   * @param {String} name
+   * @return {Boolean}
+   */
+  _engineIsLoaded(name) {
+    let owner = getOwner(this);
+    return owner.hasRegistration('engine:' + name);
+  },
+
+  /**
+   * Registers an Engine that was recently loaded.
+   *
+   * @private
+   * @method _registerEngine
+   * @param {String} name
+   * @return {Void}
+   */
+  _registerEngine(name) {
+    let owner = getOwner(this);
+    if (!owner.hasRegistration('engine:' + name)) {
+      owner.register('engine:' + name, window.require(name + '/engine').default);
+    }
+  },
+
+  /**
+   * Returns a Promise that resolves with an EngineInstance for a specific type
+   * of Engine. It fetches the Engine assets if necessary.
+   *
+   * @private
+   * @method _getEngineInstance
+   * @param {Object} engineInfo
+   * @param {String} engineInfo.name
+   * @param {String} engineInfo.instanceId
+   * @param {String} engineInfo.mountPoint
+   * @return {Promise}
+   */
+  _getEngineInstance({ name, instanceId, mountPoint }) {
+    let engineInstances = this._engineInstances;
+
+    if (!engineInstances[name]) {
+      engineInstances[name] = new EmptyObject();
+    }
+
+    let engineInstance = engineInstances[name][instanceId];
+
+    // Engine instance has already been created
+    if (engineInstance) {
+      return RSVP.resolve(engineInstance);
+    }
+
+    // Engine has been loaded but instance not created
+    if (this._engineIsLoaded(name)) {
+      engineInstance = this._constructEngineInstance(name, mountPoint);
+      engineInstances[name][instanceId] = engineInstance;
+
+      return RSVP.resolve(engineInstance);
+    }
+
+    // Engine has not been loaded
+    return engineInstances[name][instanceId] = this.get('assetLoader')
+      .loadBundle(name)
+      .then(() => {
+        this._registerEngine(name);
+        return engineInstances[name][instanceId] = this._constructEngineInstance(name, mountPoint);
+      });
+  },
+
+  /**
+   * Constructs an instance of an Engine at the specified mountPoint.
+   * TODO: Figure out if this works with nested Engines.
+   *
+   * @private
+   * @method _constructEngineInstance
+   * @param {String} name
+   * @param {String} mountPoint
+   * @return {EngineInstance} engineInstance
+   */
+  _constructEngineInstance(name, mountPoint) {
+    const owner = getOwner(this);
+
+    assert(
+      'You attempted to mount the engine \'' + name + '\' in your router map, but the engine can not be found.',
+      owner.hasRegistration(`engine:${name}`)
+    );
+
+    const engineInstance = owner.buildChildEngineInstance(name, {
+      routable: true,
+      mountPoint
+    });
+
+    engineInstance.boot();
+
+    return engineInstance;
+  }
+});

--- a/addon/initializers/engines.js
+++ b/addon/initializers/engines.js
@@ -1,5 +1,6 @@
 // Load extensions to Ember
 import '../-private/route-ext';
+import '../-private/router-ext';
 import '../-private/engine-ext';
 import '../-private/engine-instance-ext';
 

--- a/bin/install-test-addons.sh
+++ b/bin/install-test-addons.sh
@@ -3,6 +3,9 @@
 rm -rf node_modules/common-components
 ln -s ../tests/dummy/lib/common-components node_modules/common-components
 
+rm -rf node_modules/eager-blog
+ln -s ../tests/dummy/lib/eager-blog node_modules/eager-blog
+
 rm -rf node_modules/ember-blog
 ln -s ../tests/dummy/lib/ember-blog node_modules/ember-blog
 

--- a/index.js
+++ b/index.js
@@ -1,6 +1,11 @@
 /* jshint node: true */
 'use strict';
 
-module.exports = {
-  name: 'ember-engines'
-};
+var ManifestGenerator = require('ember-asset-loader/lib/manifest-generator');
+
+module.exports = ManifestGenerator.extend({
+  name: 'ember-engines',
+  manifestOptions: {
+    bundlesLocation: 'engines-dist'
+  }
+});

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.2",
     "ember-ajax": "^2.0.1",
+    "eager-blog": "file:./tests/dummy/lib/eager-blog",
     "ember-blog": "file:./tests/dummy/lib/ember-blog",
     "ember-chat": "file:./tests/dummy/lib/ember-chat",
     "ember-cli": "^2.7.0",

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "broccoli-funnel": "^1.0.0",
     "broccoli-merge-trees": "^1.0.0",
     "broccoli-plugin": "^1.2.1",
+    "ember-asset-loader": "0.1.0",
     "ember-cli-babel": "^5.1.6",
     "ember-cli-htmlbars": "^1.0.3",
     "ember-cli-string-utils": "^1.0.0",

--- a/test-support/helpers/ember-engines/preload-assets.js
+++ b/test-support/helpers/ember-engines/preload-assets.js
@@ -1,0 +1,24 @@
+import Ember from 'ember';
+import AssetLoader from 'ember-asset-loader/services/asset-loader';
+import manifest from '../../../asset-manifest';
+
+const { Test, RSVP } = Ember;
+
+/**
+ * Preloads all the bundles specified in the asset manifest
+ * to make sure all files are available for testing.
+ *
+ * Uses the Ember.Test.Promise class to make sure tests
+ * wait for the assets to load first.
+ *
+ * @return {Promise}
+ */
+export default function preloadAssets() {
+  const loader = AssetLoader.create();
+  loader.pushManifest(manifest);
+
+  const bundlePromises = Object.keys(manifest.bundles).map((bundle) => loader.loadBundle(bundle));
+  const allBundles = RSVP.all(bundlePromises);
+
+  return Test.resolve(allBundles);
+}

--- a/tests/acceptance/lazy-routeable-engine-test.js
+++ b/tests/acceptance/lazy-routeable-engine-test.js
@@ -1,19 +1,15 @@
 import Ember from 'ember';
-import { test, skip } from 'qunit';
+import { test } from 'qunit';
 import moduleForAcceptance from '../../tests/helpers/module-for-acceptance';
 import App from '../../app';
 
 const { RSVP } = Ember;
 
-
 moduleForAcceptance('Acceptance | lazy routable engine', {
   beforeEach() {
     // Remove the ember-blog to fake it having "not loaded".
-    const engineModule = window.requirejs.entries['ember-blog/engine'];
+    this._engineModule = window.requirejs.entries['ember-blog/engine'];
     window.requirejs.entries['ember-blog/engine'] = undefined;
-
-    // Reset this initializer so subsequent tests don't blow up.
-    App.instanceInitializers['stub-loader-methods'] = undefined;
 
     // We stub out the loader methods so that we can verify what they're doing.
     const module = this;
@@ -28,7 +24,7 @@ moduleForAcceptance('Acceptance | lazy routable engine', {
 
           // "Load" the engine module.
           if (uri.indexOf('engine.js') !== -1) {
-            window.requirejs.entries['ember-blog/engine'] = engineModule;
+            window.requirejs.entries['ember-blog/engine'] = module._engineModule;
           }
 
           return RSVP.resolve();
@@ -40,6 +36,13 @@ moduleForAcceptance('Acceptance | lazy routable engine', {
         });
       }
     });
+  },
+
+  afterEach() {
+    // Reset this initializer so subsequent tests don't blow up.
+    delete App.instanceInitializers['stub-loader-methods'];
+
+    window.requirejs.entries['ember-blog/engine'] = this._engineModule;
   }
 });
 
@@ -106,23 +109,23 @@ test('it should not pause to load assets on transition to a loaded, but not init
   });
 });
 
-skip('it should not pause to load assets on deep link into an eager Engine', function(assert) {
+test('it should not pause to load assets on deep link into an eager Engine', function(assert) {
   assert.expect(2);
 
-  visit('/routable-eager-engine-demo');
+  visit('/routable-engine-demo/eager-blog');
   andThen(() => {
     assert.equal(this.loadEvents.length, 0, 'no load events occured');
-    assert.equal(currentURL(), '/routeless-engine-demo');
+    assert.equal(currentURL(), '/routable-engine-demo/eager-blog');
   });
 });
 
-skip('it should not pause to load assets on transition into an eager Engine', function(assert) {
+test('it should not pause to load assets on transition into an eager Engine', function(assert) {
   assert.expect(2);
 
-  visit('/routable-eager-engine');
-  click('.blog-new:last');
+  visit('/routable-engine-demo');
+  click('.eager-blog:last');
   andThen(() => {
     assert.equal(this.loadEvents.length, 0, 'no load events occured');
-    assert.equal(currentURL(), '/routeless-engine-demo');
+    assert.equal(currentURL(), '/routable-engine-demo/eager-blog');
   });
 });

--- a/tests/acceptance/lazy-routeable-engine-test.js
+++ b/tests/acceptance/lazy-routeable-engine-test.js
@@ -1,0 +1,128 @@
+import Ember from 'ember';
+import { test, skip } from 'qunit';
+import moduleForAcceptance from '../../tests/helpers/module-for-acceptance';
+import App from '../../app';
+
+const { RSVP } = Ember;
+
+
+moduleForAcceptance('Acceptance | lazy routable engine', {
+  beforeEach() {
+    // Remove the ember-blog to fake it having "not loaded".
+    const engineModule = window.requirejs.entries['ember-blog/engine'];
+    window.requirejs.entries['ember-blog/engine'] = undefined;
+
+    // Reset this initializer so subsequent tests don't blow up.
+    App.instanceInitializers['stub-loader-methods'] = undefined;
+
+    // We stub out the loader methods so that we can verify what they're doing.
+    const module = this;
+    this.loadEvents = [];
+    this.application.instanceInitializer({
+      name: 'stub-loader-methods',
+      initialize(instance) {
+        var loader = instance.lookup('service:asset-loader');
+
+        loader.defineLoader('js', function(uri) {
+          module.loadEvents.push(uri);
+
+          // "Load" the engine module.
+          if (uri.indexOf('engine.js') !== -1) {
+            window.requirejs.entries['ember-blog/engine'] = engineModule;
+          }
+
+          return RSVP.resolve();
+        });
+
+        loader.defineLoader('css', function(uri) {
+          module.loadEvents.push(uri);
+          return RSVP.resolve();
+        });
+      }
+    });
+  }
+});
+
+function verifyInitialBlogRoute(assert, loadEvents, application) {
+  assert.equal(loadEvents.length, 3, 'loaded 3 assets');
+  assert.equal(loadEvents[0], '/engines-dist/ember-blog/assets/engine-vendor.css', 'loaded engine vendor css');
+  assert.equal(loadEvents[1], '/engines-dist/ember-blog/assets/engine-vendor.js', 'loaded engine vendor js');
+  assert.equal(loadEvents[2], '/engines-dist/ember-blog/assets/engine.js', 'loaded engine js');
+
+  assert.equal(currentURL(), '/routable-engine-demo/blog/new');
+
+  assert.equal(application.$('.routable-hello-world').text().trim(), 'Hello, world!');
+  assert.equal(application.$('.hello-name').text().trim(), 'Hello, Jerry!', 'Re-rendered hello-name component correctly');
+}
+
+test('it should pause to load JS and CSS assets on deep link into a lazy Engine', function(assert) {
+  assert.expect(7);
+
+  visit('/routable-engine-demo/blog/new');
+  andThen(() => verifyInitialBlogRoute(assert, this.loadEvents, this.application));
+});
+
+test('it should pause to load JS and CSS assets on an initial transition into a lazy Engine', function(assert) {
+  assert.expect(7);
+
+  visit('/routable-engine-demo');
+  click('.blog-new:last');
+  andThen(() => verifyInitialBlogRoute(assert, this.loadEvents, this.application));
+});
+
+test('it should not pause to load assets on subsequent transitions into a lazy Engine', function(assert) {
+  assert.expect(10);
+
+  visit('/routable-engine-demo/blog/new');
+  andThen(() => verifyInitialBlogRoute(assert, this.loadEvents, this.application));
+
+  click('.routeable-engine:last');
+  andThen(() => {
+    assert.equal(currentURL(), '/routable-engine-demo');
+  });
+
+  click('.blog-new');
+  andThen(() => {
+    assert.equal(this.loadEvents.length, 3, 'did not load additional assets');
+    assert.equal(currentURL(), '/routable-engine-demo/blog/new');
+  });
+});
+
+test('it should not pause to load assets on transition to a loaded, but not initialized instance of a lazy Engine (e.g., Engine mounted more than once)', function(assert) {
+  assert.expect(10);
+
+  visit('/routable-engine-demo/blog/new');
+  andThen(() => verifyInitialBlogRoute(assert, this.loadEvents, this.application));
+
+  click('.routeable-engine:last');
+  andThen(() => {
+    assert.equal(currentURL(), '/routable-engine-demo');
+  });
+
+  click('.ember-blog-new:last');
+  andThen(() => {
+    assert.equal(this.loadEvents.length, 3, 'did not load additional assets');
+    assert.equal(currentURL(), '/routable-engine-demo/ember-blog/new');
+  });
+});
+
+skip('it should not pause to load assets on deep link into an eager Engine', function(assert) {
+  assert.expect(2);
+
+  visit('/routable-eager-engine-demo');
+  andThen(() => {
+    assert.equal(this.loadEvents.length, 0, 'no load events occured');
+    assert.equal(currentURL(), '/routeless-engine-demo');
+  });
+});
+
+skip('it should not pause to load assets on transition into an eager Engine', function(assert) {
+  assert.expect(2);
+
+  visit('/routable-eager-engine');
+  click('.blog-new:last');
+  andThen(() => {
+    assert.equal(this.loadEvents.length, 0, 'no load events occured');
+    assert.equal(currentURL(), '/routeless-engine-demo');
+  });
+});

--- a/tests/acceptance/routeable-engine-demo-test.js
+++ b/tests/acceptance/routeable-engine-demo-test.js
@@ -30,7 +30,7 @@ test('can deserialize a route\'s params', function(assert) {
   });
 });
 
-test('can restore unspecified query parameters', function(assert) {
+test('correctly handles missing default query params', function(assert) {
   assert.expect(2);
 
   visit('/routable-engine-demo/blog/post/1?lang=English');
@@ -38,7 +38,7 @@ test('can restore unspecified query parameters', function(assert) {
   click('.back-to-post-link');
 
   andThen(() => {
-    assert.equal(currentURL(), '/routable-engine-demo/blog/post/1?lang=English');
+    assert.equal(currentURL(), '/routable-engine-demo/blog/post/1');
 
     assert.equal(this.application.$('p.language').text().trim(), 'English');
   });

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -20,6 +20,8 @@ Router.map(function() {
     this.mount('ember-blog', { as: 'dev-blog', resetNamespace: true });
 
     this.mount('ember-blog', { as: 'admin-blog', path: '/special-admin-blog-here' });
+
+    this.mount('eager-blog', { resetNamespace: true });
   });
 });
 

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -1,5 +1,6 @@
 <h1>Ember Engines Demo</h1>
 
-{{link-to 'Routeless Engine' 'routeless-engine-demo'}} | {{link-to 'Routeable Engine' 'routable-engine-demo'}}
+{{link-to 'Routeless Engine' 'routeless-engine-demo' class='routeless-engine'}} |
+{{link-to 'Routeable Engine' 'routable-engine-demo' class='routeable-engine'}}
 
 {{outlet}}

--- a/tests/dummy/app/templates/routable-engine-demo.hbs
+++ b/tests/dummy/app/templates/routable-engine-demo.hbs
@@ -1,5 +1,6 @@
 <div>
-  {{link-to 'Blog New' 'blog.new'}}
+  {{link-to 'Blog New' 'blog.new' class='blog-new'}} |
+  {{link-to 'Ember Blog New' 'routable-engine-demo.ember-blog.new' class='ember-blog-new'}}
 </div>
 
 {{outlet}}

--- a/tests/dummy/app/templates/routable-engine-demo.hbs
+++ b/tests/dummy/app/templates/routable-engine-demo.hbs
@@ -1,6 +1,7 @@
 <div>
   {{link-to 'Blog New' 'blog.new' class='blog-new'}} |
-  {{link-to 'Ember Blog New' 'routable-engine-demo.ember-blog.new' class='ember-blog-new'}}
+  {{link-to 'Ember Blog New' 'routable-engine-demo.ember-blog.new' class='ember-blog-new'}} |
+  {{link-to 'Eager Blog' 'eager-blog' class='eager-blog'}}
 </div>
 
 {{outlet}}

--- a/tests/dummy/lib/eager-blog/addon/engine.js
+++ b/tests/dummy/lib/eager-blog/addon/engine.js
@@ -1,0 +1,15 @@
+import Engine from 'ember-engines/engine';
+import Resolver from 'ember-engines/resolver';
+import loadInitializers from 'ember-load-initializers';
+import config from './config/environment';
+
+const { modulePrefix } = config;
+
+const Eng = Engine.extend({
+  modulePrefix,
+  Resolver
+});
+
+loadInitializers(Eng, modulePrefix);
+
+export default Eng;

--- a/tests/dummy/lib/eager-blog/addon/routes.js
+++ b/tests/dummy/lib/eager-blog/addon/routes.js
@@ -1,0 +1,3 @@
+import buildRoutes from 'ember-engines/routes';
+
+export default buildRoutes(function() {});

--- a/tests/dummy/lib/eager-blog/addon/templates/application.hbs
+++ b/tests/dummy/lib/eager-blog/addon/templates/application.hbs
@@ -1,0 +1,1 @@
+<h3 class='title'>Eager engine</h3>

--- a/tests/dummy/lib/eager-blog/ember-config/environment.js
+++ b/tests/dummy/lib/eager-blog/ember-config/environment.js
@@ -1,0 +1,11 @@
+/*jshint node:true*/
+'use strict';
+
+module.exports = function(environment) {
+  var ENV = {
+    modulePrefix: 'eager-blog',
+    environment: environment
+  };
+
+  return ENV;
+};

--- a/tests/dummy/lib/eager-blog/index.js
+++ b/tests/dummy/lib/eager-blog/index.js
@@ -1,0 +1,16 @@
+/*jshint node:true*/
+var EngineAddon = require('../../../../lib/engine-addon');
+
+module.exports = EngineAddon.extend({
+  name: 'eager-blog',
+
+  isDevelopingAddon: function() {
+    return true;
+  },
+
+  hintingEnabled: function() {
+    return false;
+  },
+
+  lazyLoading: false
+});

--- a/tests/dummy/lib/eager-blog/package.json
+++ b/tests/dummy/lib/eager-blog/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "eager-blog",
+  "version": "0.0.0",
+  "keywords": [
+    "ember-addon",
+    "ember-engine"
+  ],
+  "ember-addon": {
+    "engineConfigPath": "ember-config"
+  },
+  "dependencies": {
+    "ember-cli-htmlbars": "*"
+  }
+}

--- a/tests/dummy/lib/ember-blog/index.js
+++ b/tests/dummy/lib/ember-blog/index.js
@@ -10,5 +10,7 @@ module.exports = EngineAddon.extend({
 
   hintingEnabled: function() {
     return false;
-  }
+  },
+
+  lazyLoading: true
 });

--- a/tests/test-helper.js
+++ b/tests/test-helper.js
@@ -2,5 +2,8 @@ import resolver from './helpers/resolver';
 import {
   setResolver
 } from 'ember-qunit';
+import preloadAssets from './helpers/ember-engines/preload-assets';
+
+preloadAssets();
 
 setResolver(resolver);

--- a/tests/unit/engine-instance-test.js
+++ b/tests/unit/engine-instance-test.js
@@ -4,6 +4,9 @@ import Engine from 'ember-engines/engine';
 import emberRequire from 'ember-engines/-private/ext-require';
 import { module, test } from 'qunit';
 
+import Resolver from '../../resolver';
+import config from '../../config/environment';
+
 const getEngineParent = emberRequire('ember-application/system/engine-parent', 'getEngineParent');
 
 const {
@@ -18,6 +21,8 @@ module('Unit | EngineInstance', {
     EnginesInitializer.initialize();
 
     App = Application.extend({
+      Resolver,
+      modulePrefix: config.modulePrefix,
       router: null
     });
 
@@ -57,9 +62,6 @@ test('it can build a child engine instance with no dependencies', function(asser
 
 test('it can build a child engine instance with dependencies', function(assert) {
   assert.expect(3);
-
-  let storeService = {};
-  app.register('service:store', storeService, { instantiate: false });
 
   let BlogEngine = Engine.extend({
     router: null,
@@ -101,9 +103,6 @@ test('it can build a child engine instance with dependencies', function(assert) 
 
 test('it can build a child engine instance with dependencies that are aliased', function(assert) {
   assert.expect(3);
-
-  let storeService = {};
-  app.register('service:store', storeService, { instantiate: false });
 
   let BlogEngine = Engine.extend({
     router: null,


### PR DESCRIPTION
This is the complement to the Lazy Load Build PR (#173). There are three main parts to this PR:

1. Generate an Asset Manifest from the build assets of lazy engines (accomplished via [ember-asset-loader](https://github.com/trentmwillis/ember-asset-loader)).
2. Load lazy Engine assets dynamically at runtime (this is the bulk of the PR)
3. Modify default query params behavior such that they are ignored for Engines (otherwise we'll blow up on lazy Engines).

Todo:
- [x] Fix `handler.actions is undefined` error [[PR](https://github.com/emberjs/ember.js/pull/14087)]
- [x] Fix tests failing due to lazy loading
  - [x] Determine approach for testing lazily loaded code [`preloadAssets`]
  - [ ] Move `preloadAssets` to `ember-asset-loader` [[PR](https://github.com/trentmwillis/ember-asset-loader/pull/15)]
- [x] Write tests to verify behavior
- [x] Cleanup / document / polish