### PR TITLE
Make transitionToRoute() and intermediateTransitionTo() work in engines

### DIFF
--- a/addon/-private/controller-ext.js
+++ b/addon/-private/controller-ext.js
@@ -1,0 +1,8 @@
+import Ember from 'ember';
+import { prefixRouteNameArg } from './utils';
+
+Ember.Controller.reopen({
+  transitionToRoute(...args) {
+    return this._super.apply(this, (prefixRouteNameArg.call(this, 'Controller#transitionToRoute', ...args)));
+  }
+});

--- a/addon/-private/route-ext.js
+++ b/addon/-private/route-ext.js
@@ -1,36 +1,15 @@
 import Ember from 'ember';
+import { prefixRouteNameArg } from './utils';
 import emberRequire from './ext-require';
 
 const {
   get,
   Route,
-  getOwner,
-  Error: EmberError
+  getOwner
 } = Ember;
 
 const assign = emberRequire('ember-metal/assign');
 const emberA = emberRequire('ember-runtime/system/native_array', 'A');
-
-/*
-  Returns an arguments array where the route name arg is prefixed based on the mount point
-*/
-function prefixRouteNameArg(...args) {
-  let routeName = args[0];
-  let owner = getOwner(this);
-  let prefix = owner.mountPoint;
-
-  // only alter the routeName if it's actually referencing a route.
-  if (owner.routable && typeof routeName === 'string') {
-    if (resemblesURL(routeName)) {
-      throw new EmberError('Route#transitionTo cannot be used for URLs. Please use the route name instead.');
-    } else {
-      routeName = `${prefix}.${routeName}`;
-      args[0] = routeName;
-    }
-  }
-
-  return args;
-}
 
 /*
   Creates an aliased form of a method that properly resolves external routes.
@@ -76,11 +55,15 @@ Route.reopen({
   },
 
   replaceWith(...args) {
-    return this._super.apply(this, (prefixRouteNameArg.call(this, ...args)));
+    return this._super.apply(this, (prefixRouteNameArg.call(this, 'Route#replaceWith', ...args)));
   },
 
   transitionTo(...args) {
-    return this._super.apply(this, (prefixRouteNameArg.call(this, ...args)));
+    return this._super.apply(this, (prefixRouteNameArg.call(this, 'Route#transitionTo', ...args)));
+  },
+
+  intermediateTransitionTo(...args) {
+    return this._super.apply(this, (prefixRouteNameArg.call(this, 'Route#intermediateTransitionTo', ...args)));
   },
 
   transitionToExternal: externalAlias('transitionTo'),
@@ -107,11 +90,6 @@ Route.reopen({
     return this._super(routeName, ...args);
   }
 });
-
-// Cloned private function required to check if a routeName resembles a url instead
-function resemblesURL(str) {
-  return typeof str === 'string' && ( str === '' || str.charAt(0) === '/');
-}
 
 // Cloned private function required to support `paramsFor` override
 function getFullQueryParams(router, state) {

--- a/addon/-private/utils.js
+++ b/addon/-private/utils.js
@@ -1,0 +1,32 @@
+import Ember from 'ember';
+
+const {
+  getOwner,
+  Error: EmberError
+} = Ember;
+
+/*
+  Returns an arguments array where the route name arg is prefixed based on the mount point
+*/
+export function prefixRouteNameArg(funcName, ...args) {
+  let routeName = args[0];
+  let owner = getOwner(this);
+  let prefix = owner.mountPoint;
+
+  // only alter the routeName if it's actually referencing a route.
+  if (owner.routable && typeof routeName === 'string') {
+    if (resemblesURL(routeName)) {
+      throw new EmberError(`${funcName} cannot be used for URLs. Please use the route name instead.`);
+    } else {
+      routeName = `${prefix}.${routeName}`;
+      args[0] = routeName;
+    }
+  }
+
+  return args;
+}
+
+// Cloned private function required to check if a routeName resembles a url instead
+function resemblesURL(str) {
+  return typeof str === 'string' && ( str === '' || str.charAt(0) === '/');
+}

--- a/addon/initializers/engines.js
+++ b/addon/initializers/engines.js
@@ -1,4 +1,5 @@
 // Load extensions to Ember
+import '../-private/controller-ext';
 import '../-private/route-ext';
 import '../-private/router-ext';
 import '../-private/engine-ext';

--- a/tests/acceptance/routeable-engine-demo-test.js
+++ b/tests/acceptance/routeable-engine-demo-test.js
@@ -87,6 +87,29 @@ test('a route can use transitionTo to transition to internal route', function(as
   });
 });
 
+test('a controller can use transitionToRoute to transition to internal route', function(assert) {
+  assert.expect(1);
+
+  visit('/routable-engine-demo/blog/new');
+  click('.trigger-transition-to-route');
+
+  andThen(() => {
+    assert.equal(currentURL(), '/routable-engine-demo/blog/post/1');
+  });
+});
+
+test('a route can use intermediateTransitionTo to transition to another route', function(assert) {
+  assert.expect(2);
+
+  visit('/routable-engine-demo/blog/new');
+  click('.trigger-intermediate-transition-to');
+
+  andThen(() => {
+    assert.equal(currentURL(), '/routable-engine-demo/blog/new');
+    assert.ok(this.application.$('.transient-route-message').text().trim());
+  });
+});
+
 test('internal links can be clicked', function(assert) {
   assert.expect(1);
 

--- a/tests/dummy/lib/ember-blog/addon/controllers/new.js
+++ b/tests/dummy/lib/ember-blog/addon/controllers/new.js
@@ -1,0 +1,9 @@
+import Ember from 'ember';
+
+export default Ember.Controller.extend({
+  actions: {
+    goAwayViaController() {
+      this.transitionToRoute('post', 1);
+    }
+  }
+});

--- a/tests/dummy/lib/ember-blog/addon/routes.js
+++ b/tests/dummy/lib/ember-blog/addon/routes.js
@@ -8,6 +8,8 @@ export default buildRoutes(function() {
       this.route('comment', { path: ':id' });
     });
   });
+
+  this.route('transient-route');
 });
 
 // {{link-to 'blog.comments.comment'}}

--- a/tests/dummy/lib/ember-blog/addon/routes/new.js
+++ b/tests/dummy/lib/ember-blog/addon/routes/new.js
@@ -10,6 +10,10 @@ export default Ember.Route.extend({
       this.transitionTo('post', 1);
     },
 
+    goAwayViaIntermediate() {
+      this.intermediateTransitionTo('transient-route');
+    },
+
     goAwayViaURL() {
       this.transitionTo('/post/1');
     }

--- a/tests/dummy/lib/ember-blog/addon/routes/transient-route.js
+++ b/tests/dummy/lib/ember-blog/addon/routes/transient-route.js
@@ -1,0 +1,6 @@
+import Ember from 'ember';
+
+export default Ember.Route.extend({
+  model() {
+  }
+});

--- a/tests/dummy/lib/ember-blog/addon/templates/new.hbs
+++ b/tests/dummy/lib/ember-blog/addon/templates/new.hbs
@@ -4,5 +4,7 @@
   {{hello-world class="routable-hello-world"}}
 
   <button {{action 'goAway'}} class="trigger-transition-to">Go Away!</button>
+  <button {{action 'goAwayViaIntermediate'}} class="trigger-intermediate-transition-to">Go Away Temporary!</button>
+  <button {{action 'goAwayViaController'}} class="trigger-transition-to-route">Go Away via Controller!</button>
   <button {{action 'goAwayViaURL'}} class="trigger-transition-to-url">Go Away via URL!</button>
 </div>

--- a/tests/dummy/lib/ember-blog/addon/templates/transient-route.hbs
+++ b/tests/dummy/lib/ember-blog/addon/templates/transient-route.hbs
@@ -1,0 +1,1 @@
+<div class="transient-route-message">Should leave this page shortly...</div>


### PR DESCRIPTION
The PR fixes #186 and #159 in v0.2 branch.

I've added tests, but the one for `intermediateTransitionTo()` is somewhat clunky. I couldn't think of a better way.