### PR TITLE
ApplicationInstance.boot() fails because of missing engine parent

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "ember-engines",
   "dependencies": {
-    "ember": "~2.7.0",
+    "ember": "~2.7.3",
     "ember-cli-shims": "0.1.1",
     "ember-cli-test-loader": "0.2.2",
     "ember-qunit-notifications": "0.1.0"

--- a/tests/acceptance/bugs-test.js
+++ b/tests/acceptance/bugs-test.js
@@ -1,0 +1,23 @@
+import Ember from 'ember';
+import { test } from 'qunit';
+import moduleForAcceptance from '../helpers/module-for-acceptance';
+
+moduleForAcceptance('Acceptance | Bugs');
+
+test('should be possible to build and boot an application instance', function (assert) {
+  const application = this.application;
+  const instance = application.buildInstance();
+
+  // append new div to be the root element for this instance
+  Ember.$('#ember-testing').parent().append('<div id="test-app-instance"></div>');
+
+  let success;
+  Ember.run(() => {
+    // boot the instance and wait for it to finish
+    instance.boot({
+      rootElement: '#test-app-instance'
+    }).then(() => success = true, () => success = false);
+  });
+
+  assert.ok(success, 'Expected instance to boot without problems');
+});


### PR DESCRIPTION
There is a check for set engine parent, when trying to boot an `ApplicationInstance`, created with `Application.buildInstance()`.

The test pass on Ember 2.6.2 and fails on Ember 2.7.3. The reason is that in 2.6, the ApplicationInstance overrode both `boot` and `_bootSync`, with its own copy and the check for the engine parent is not done. In 2.7, `ApplicationInstance` only overrides `_bootSync`, which leaves the engine parent check to be done in the `boot()` section.
