### PR TITLE
Remove usage of EmptyObject.

### DIFF
--- a/addon/-private/link-to-component.js
+++ b/addon/-private/link-to-component.js
@@ -1,4 +1,5 @@
 import Ember from 'ember';
+import { attributeMungingMethod } from './link-to-utils';
 
 const {
   LinkComponent,
@@ -8,7 +9,7 @@ const {
 } = Ember;
 
 export default LinkComponent.extend({
-  willRender() {
+  [attributeMungingMethod]() {
     this._super(...arguments);
 
     let owner = getOwner(this);

--- a/addon/-private/link-to-external-component.js
+++ b/addon/-private/link-to-external-component.js
@@ -1,4 +1,5 @@
 import Ember from 'ember';
+import { attributeMungingMethod } from './link-to-utils';
 
 const {
   LinkComponent,
@@ -8,7 +9,7 @@ const {
 } = Ember;
 
 export default LinkComponent.extend({
-  willRender() {
+  [attributeMungingMethod]() {
     this._super(...arguments);
 
     const owner = getOwner(this);

--- a/addon/-private/link-to-utils.js
+++ b/addon/-private/link-to-utils.js
@@ -1,0 +1,17 @@
+import Ember from 'ember';
+
+// LAME, but ¯\_(ツ)_/¯
+export default function hasEmberVersion(major, minor) {
+  var numbers = Ember.VERSION.split('-')[0].split('.');
+  var actualMajor = parseInt(numbers[0], 10);
+  var actualMinor = parseInt(numbers[1], 10);
+  return actualMajor > major || (actualMajor === major && actualMinor >= minor);
+}
+
+export const attributeMungingMethod = (function() {
+  if (hasEmberVersion(2, 9)) {
+    return 'didReceiveAttrs';
+  } else {
+    return `willRender`;
+  }
+})();

--- a/addon/-private/router-ext.js
+++ b/addon/-private/router-ext.js
@@ -2,7 +2,6 @@ import Ember from 'ember';
 import emberRequire from './ext-require';
 
 const hasDefaultSerialize = emberRequire('ember-routing/system/route', 'hasDefaultSerialize');
-const EmptyObject = emberRequire('ember-metal/empty_object');
 
 const {
   Logger: {
@@ -39,7 +38,7 @@ Router.reopen({
    * @override
    */
   _getHandlerFunction() {
-    let seen = new EmptyObject();
+    let seen = Object.create(null);
     let owner = getOwner(this);
 
     return (name) => {
@@ -146,7 +145,7 @@ Router.reopen({
     let engineInstances = this._engineInstances;
 
     if (!engineInstances[name]) {
-      engineInstances[name] = new EmptyObject();
+      engineInstances[name] = Object.create(null);
     }
 
     let engineInstance = engineInstances[name][instanceId];

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "broccoli-funnel": "^1.0.0",
     "broccoli-merge-trees": "^1.0.0",
     "broccoli-plugin": "^1.2.1",
-    "ember-asset-loader": "0.1.1",
+    "ember-asset-loader": "^0.1.4",
     "ember-cli-babel": "^5.1.6",
     "ember-cli-htmlbars": "^1.0.3",
     "ember-cli-string-utils": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "broccoli-funnel": "^1.0.0",
     "broccoli-merge-trees": "^1.0.0",
     "broccoli-plugin": "^1.2.1",
-    "ember-asset-loader": "^0.1.4",
+    "ember-asset-loader": "^0.1.5",
     "ember-cli-babel": "^5.1.6",
     "ember-cli-htmlbars": "^1.0.3",
     "ember-cli-string-utils": "^1.0.0",


### PR DESCRIPTION
`EmptyObject` in Ember is an attempt to make creating `Object.create(null)` objects faster by avoiding the creation of an object with a null prototype.

In our case, these objects are not being created in a hot path repeatedly so the performance concern is not valid. Using `Object.create(null)` directly reduces our coupling to changes in Ember and embraces "the platform" (:troll:).

Fixes #196.