### PR TITLE
Bump ember-asset-loader for FastBoot/SSR support

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "broccoli-funnel": "^1.0.0",
     "broccoli-merge-trees": "^1.0.0",
     "broccoli-plugin": "^1.2.1",
-    "ember-asset-loader": "^0.1.5",
+    "ember-asset-loader": "^0.2.0",
     "ember-cli-babel": "^5.1.6",
     "ember-cli-htmlbars": "^1.0.3",
     "ember-cli-string-utils": "^1.0.0",

--- a/tests/test-helper.js
+++ b/tests/test-helper.js
@@ -3,7 +3,7 @@ import {
   setResolver
 } from 'ember-qunit';
 import preloadAssets from 'ember-asset-loader/test-support/preload-assets';
-import manifest from '../asset-manifest';
+import manifest from '../config/asset-manifest';
 
 preloadAssets(manifest);
 


### PR DESCRIPTION
Relevant issue to see what this changes: https://github.com/trentmwillis/ember-asset-loader/issues/21.

Testing with our LinkedIn app shows that the app can boot successfully in a FastBoot like environment.