### PR TITLE
[v0.3] Fix link-to for Glimmer2 and ember-try update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,4 @@ install:
   - bower install
 
 script:
-  # Usually, it's ok to finish the test scenario without reverting
-  #  to the addon's original dependency state, skipping "cleanup".
-  - ember try $EMBER_TRY_SCENARIO test --skip-cleanup
+  - ember try:each test

--- a/addon/-private/link-to-component.js
+++ b/addon/-private/link-to-component.js
@@ -1,4 +1,5 @@
 import Ember from 'ember';
+import { attributeMungingMethod } from './link-to-utils';
 
 const {
   LinkComponent,
@@ -8,7 +9,7 @@ const {
 } = Ember;
 
 export default LinkComponent.extend({
-  willRender() {
+  [attributeMungingMethod]() {
     this._super(...arguments);
 
     let owner = getOwner(this);

--- a/addon/-private/link-to-external-component.js
+++ b/addon/-private/link-to-external-component.js
@@ -1,4 +1,5 @@
 import Ember from 'ember';
+import { attributeMungingMethod } from './link-to-utils';
 
 const {
   LinkComponent,
@@ -8,7 +9,7 @@ const {
 } = Ember;
 
 export default LinkComponent.extend({
-  willRender() {
+  [attributeMungingMethod]() {
     this._super(...arguments);
 
     const owner = getOwner(this);

--- a/addon/-private/link-to-utils.js
+++ b/addon/-private/link-to-utils.js
@@ -1,0 +1,17 @@
+import Ember from 'ember';
+
+// LAME, but ¯\_(ツ)_/¯
+export default function hasEmberVersion(major, minor) {
+  var numbers = Ember.VERSION.split('-')[0].split('.');
+  var actualMajor = parseInt(numbers[0], 10);
+  var actualMinor = parseInt(numbers[1], 10);
+  return actualMajor > major || (actualMajor === major && actualMinor >= minor);
+}
+
+export const attributeMungingMethod = (function() {
+  if (hasEmberVersion(2, 9)) {
+    return 'didReceiveAttrs';
+  } else {
+    return `willRender`;
+  }
+})();

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -2,30 +2,24 @@
 module.exports = {
   scenarios: [
     {
-      name: 'default',
-      bower: {
-        dependencies: { }
-      }
-    },
-    {
-      name: 'ember-1.13',
+      name: 'ember-2.8',
       bower: {
         dependencies: {
-          'ember': '~1.13.0'
+          'ember': '~2.8.0'
         },
         resolutions: {
-          'ember': '~1.13.0'
+          'ember': '~2.8.0'
         }
       }
     },
     {
-      name: 'ember-release',
+      name: 'ember-2.9',
       bower: {
         dependencies: {
-          'ember': 'components/ember#release'
+          'ember': '~2.9.0-beta.2'
         },
         resolutions: {
-          'ember': 'release'
+          'ember': '~2.9.0-beta.2'
         }
       }
     },
@@ -42,6 +36,7 @@ module.exports = {
     },
     {
       name: 'ember-canary',
+      allowedToFail: true,
       bower: {
         dependencies: {
           'ember': 'components/ember#canary'


### PR DESCRIPTION
Replacing #201, by not including the #200 re-work which is still up in the air.