### PR TITLE
Remove confusing instructions

### DIFF
--- a/guides/05-mounting-engines.md
+++ b/guides/05-mounting-engines.md
@@ -2,18 +2,6 @@
 
 Now that we have our Engine created, let's actually mount it so that we can see it in action.
 
-```js
-// tests/dummy/app/resolver.js
-import Resolver from 'ember-resolver';
-```
-
-Update it to:
-
-```js
-// tests/dummy/app/resolver.js
-import Resolver from 'ember-resolver';
-```
-
 ## Creating Engine Templates
 
 In order to actually tell that our Engine renders properly, we need to add a template.


### PR DESCRIPTION
After [51e1abe](https://github.com/dgeb/ember-engines/commit/51e1abe9493c552043756e0b95a857f28144bb55) , these instructions became unnecessary and confusing.