### PR TITLE
Fix query params and add tests

### DIFF
--- a/addon/-private/router-ext.js
+++ b/addon/-private/router-ext.js
@@ -18,14 +18,16 @@ Router.reopen({
   assetLoader: Ember.inject.service(),
 
   /**
-   * We skip doing default query params stuff when attempting to go to an
-   * Engine route.
+   * When going to an Engine route, we check for QP meta in the BucketCache
+   * instead of checking the Route (which may not exist yet). We populate
+   * the BucketCache after loading the Route the first time.
    *
    * @override
    */
-  _prepareQueryParams(routeName) {
+  _getQPMeta(handlerInfo) {
+    let routeName = handlerInfo.name;
     if (this._engineInfoByRoute[routeName]) {
-      return;
+      return this._bucketCache.lookup('route-meta', routeName);
     }
 
     return this._super(...arguments);
@@ -95,7 +97,8 @@ Router.reopen({
       }
     }
 
-    handler.routeName = localRouteName;
+    handler._setRouteName(localRouteName);
+    handler._populateQPMeta();
 
     return handler;
   },

--- a/tests/acceptance/routeable-engine-demo-test.js
+++ b/tests/acceptance/routeable-engine-demo-test.js
@@ -30,17 +30,151 @@ test('can deserialize a route\'s params', function(assert) {
   });
 });
 
-test('correctly handles missing default query params', function(assert) {
+test('correctly handles navigation with query param in initial url', function(assert) {
+  assert.expect(9);
+
+  visit('/routable-engine-demo/blog/post/1?lang=English');
+  andThen(() => {
+    assert.equal(currentURL(), '/routable-engine-demo/blog/post/1?lang=English', 'url is visited properly');
+    assert.equal(this.application.$('p.language').text().trim(), 'English', 'query param value is passed through correctly - 1');
+  });
+
+  click('.routable-post-comments-link');
+  andThen(() => {
+    assert.equal(currentURL(), '/routable-engine-demo/blog/post/1/comments?lang=English', 'query param is carried to sub-route');
+    assert.equal(this.application.$('p.language').text().trim(), 'English', 'query param value is passed through correctly - 2');
+  });
+
+
+  click('.back-to-post-link');
+  andThen(() => {
+    assert.equal(currentURL(), '/routable-engine-demo/blog/post/1?lang=English', 'query param is carried back to original route properly');
+    assert.equal(this.application.$('p.language').text().trim(), 'English', 'query param value is passed through correctly - 3');
+  });
+
+  click('.routable-post-blog-home-link');
+  andThen(() => {
+    assert.equal(currentURL(), '/routable-engine-demo/blog', 'query param is removed when changing route hierarchy');
+  });
+
+  click('.routable-post-1-link');
+  andThen(() => {
+    assert.equal(currentURL(), '/routable-engine-demo/blog/post/1?lang=English', 'query param is rehydrated in url');
+    assert.equal(this.application.$('p.language').text().trim(), 'English', 'query param value is passed through correctly - 4');
+  });
+});
+
+test('can link-to a route with query params from outside an Engine', function(assert) {
+  assert.expect(2);
+
+  visit('/routable-engine-demo');
+  click('.blog-post-1-link-jp');
+  andThen(() => {
+    assert.equal(currentURL(), '/routable-engine-demo/blog/post/1?lang=Japanese');
+    assert.equal(this.application.$('p.language').text().trim(), 'Japanese');
+  });
+});
+
+test('can programmatically transition to a route with query params from outside an Engine', function(assert) {
+  assert.expect(2);
+
+  visit('/routable-engine-demo');
+  click('.blog-post-1-link-ch');
+  andThen(() => {
+    assert.equal(currentURL(), '/routable-engine-demo/blog/post/1?lang=Chinese');
+    assert.equal(this.application.$('p.language').text().trim(), 'Chinese');
+  });
+});
+
+test('can link-to a route with query params within an Engine', function(assert) {
+  assert.expect(2);
+
+  visit('/routable-engine-demo/blog');
+  click('.routable-post-1-link-jp');
+  andThen(() => {
+    assert.equal(currentURL(), '/routable-engine-demo/blog/post/1?lang=Japanese');
+    assert.equal(this.application.$('p.language').text().trim(), 'Japanese');
+  });
+});
+
+test('can programmatically transition to a route with query params within an Engine', function(assert) {
+  assert.expect(2);
+
+  visit('/routable-engine-demo/blog');
+  click('.routable-post-1-link-ch');
+  andThen(() => {
+    assert.equal(currentURL(), '/routable-engine-demo/blog/post/1?lang=Chinese');
+    assert.equal(this.application.$('p.language').text().trim(), 'Chinese');
+  });
+});
+
+test('can perform a QP-only link-to transition', function(assert) {
   assert.expect(2);
 
   visit('/routable-engine-demo/blog/post/1?lang=English');
-  click('.routable-post-comments-link');
-  click('.back-to-post-link');
-
+  click('.routable-post-jp-link');
   andThen(() => {
-    assert.equal(currentURL(), '/routable-engine-demo/blog/post/1');
+    assert.equal(currentURL(), '/routable-engine-demo/blog/post/1?lang=Japanese', 'URL is updated properly');
+    assert.equal(this.application.$('p.language').text().trim(), 'Japanese', 'DOM is updated properly');
+  });
+});
 
-    assert.equal(this.application.$('p.language').text().trim(), 'English');
+test('can perform a QP-only transitionTo', function(assert) {
+  assert.expect(2);
+
+  visit('/routable-engine-demo/blog/post/1?lang=English');
+  click('.routable-post-ch-link');
+  andThen(() => {
+    assert.equal(currentURL(), '/routable-engine-demo/blog/post/1?lang=Chinese', 'URL is updated properly');
+    assert.equal(this.application.$('p.language').text().trim(), 'Chinese', 'DOM is updated properly');
+  });
+});
+
+test('can perform a redirect transition with QP', function(assert) {
+  assert.expect(1);
+
+  visit('/routable-engine-demo/redirect');
+  andThen(() => {
+    assert.equal(currentURL(), '/routable-engine-demo/blog/post/1?lang=English');
+  });
+});
+
+test('can perform an afterModel transition with QP', function(assert) {
+  assert.expect(1);
+
+  visit('/routable-engine-demo/after-model/3');
+  andThen(() => {
+    assert.equal(currentURL(), '/routable-engine-demo/blog/post/3?lang=English');
+  });
+});
+
+test('query param bucket cache does not collide when starting outside Engine', function(assert) {
+  assert.expect(2);
+
+  visit('/post/1?lang=English');
+  click('.blog-post-no-qp');
+  andThen(() => {
+    assert.equal(currentURL(), '/routable-engine-demo/blog/post/1','URL does not have any query params');
+  });
+
+  click('.non-blog-post');
+  andThen(() => {
+    assert.equal(currentURL(), '/post/1?lang=English', 'URL has original query params');
+  });
+});
+
+test('query param bucket cache does not collide when starting inside Engine', function(assert) {
+  assert.expect(2);
+
+  visit('/routable-engine-demo/blog/post/1?lang=English');
+  click('.non-blog-post');
+  andThen(() => {
+    assert.equal(currentURL(), '/post/1', 'URL does not have any query params');
+  });
+
+  click('.blog-post-no-qp');
+  andThen(() => {
+    assert.equal(currentURL(), '/routable-engine-demo/blog/post/1?lang=English', 'URL has original query params');
   });
 });
 

--- a/tests/dummy/app/controllers/post.js
+++ b/tests/dummy/app/controllers/post.js
@@ -1,0 +1,5 @@
+import Ember from 'ember';
+
+export default Ember.Controller.extend({
+  queryParams: ['lang']
+});

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -10,6 +10,9 @@ Router.map(function() {
 
   this.route('routable-engine-demo', function() {
     this.route('normal-route');
+    this.route('redirect');
+    this.route('after-model', { path: '/after-model/:id' });
+
 
     this.mount('ember-blog');
 
@@ -23,6 +26,9 @@ Router.map(function() {
 
     this.mount('eager-blog', { resetNamespace: true });
   });
+
+  // Used to check for collisions with Post route in ember-blog
+  this.route('post', { path: '/post/:id' });
 });
 
 export default Router;

--- a/tests/dummy/app/routes/routable-engine-demo/after-model.js
+++ b/tests/dummy/app/routes/routable-engine-demo/after-model.js
@@ -1,0 +1,7 @@
+import Ember from 'ember';
+
+export default Ember.Route.extend({
+  afterModel(model) {
+    this.replaceWith('blog.post', model.id, { queryParams: { lang: 'English' } });
+  }
+});

--- a/tests/dummy/app/routes/routable-engine-demo/index.js
+++ b/tests/dummy/app/routes/routable-engine-demo/index.js
@@ -1,0 +1,9 @@
+import Ember from 'ember';
+
+export default Ember.Route.extend({
+  actions: {
+    goToPostWithChinese() {
+      this.transitionTo('blog.post', 1, { queryParams: { lang: 'Chinese' } });
+    }
+  }
+});

--- a/tests/dummy/app/routes/routable-engine-demo/redirect.js
+++ b/tests/dummy/app/routes/routable-engine-demo/redirect.js
@@ -1,0 +1,7 @@
+import Ember from 'ember';
+
+export default Ember.Route.extend({
+  redirect() {
+    this.replaceWith('blog.post', 1, { queryParams: { lang: 'English' } });
+  }
+});

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -1,6 +1,7 @@
 <h1>Ember Engines Demo</h1>
 
 {{link-to 'Routeless Engine' 'routeless-engine-demo' class='routeless-engine'}} |
-{{link-to 'Routeable Engine' 'routable-engine-demo' class='routeable-engine'}}
+{{link-to 'Routeable Engine' 'routable-engine-demo' class='routeable-engine'}} |
+{{link-to 'Non-Blog Post' 'post' 1 class='non-blog-post'}}
 
 {{outlet}}

--- a/tests/dummy/app/templates/post.hbs
+++ b/tests/dummy/app/templates/post.hbs
@@ -1,0 +1,3 @@
+<p class="language">{{lang}}</p>
+
+{{#link-to "blog.post" 1 class="blog-post-no-qp"}}Go to Blog Post with no Query Params{{/link-to}}

--- a/tests/dummy/app/templates/routable-engine-demo/index.hbs
+++ b/tests/dummy/app/templates/routable-engine-demo/index.hbs
@@ -1,0 +1,4 @@
+<ul>
+  <li>{{#link-to 'blog.post' 1 (query-params lang="Japanese") class="blog-post-1-link-jp"}}Go to post #1 with Japanese as language{{/link-to}}</li>
+  <li><button {{action "goToPostWithChinese"}} class="blog-post-1-link-ch">Go to post #1 with Chinese as language programmatically</button></li>
+</ul>

--- a/tests/dummy/lib/ember-blog/addon/routes/index.js
+++ b/tests/dummy/lib/ember-blog/addon/routes/index.js
@@ -1,0 +1,9 @@
+import Ember from 'ember';
+
+export default Ember.Route.extend({
+  actions: {
+    goToPostWithChinese() {
+      this.transitionTo('post', 1, { queryParams: { lang: 'Chinese' } });
+    }
+  }
+});

--- a/tests/dummy/lib/ember-blog/addon/routes/post.js
+++ b/tests/dummy/lib/ember-blog/addon/routes/post.js
@@ -8,5 +8,11 @@ export default Ember.Route.extend({
       id: params.id,
       title: `Post ${params.id}`
     };
+  },
+
+  actions: {
+    goToChineseVersion() {
+      this.transitionTo({ queryParams: { lang: 'Chinese' } });
+    }
   }
 });

--- a/tests/dummy/lib/ember-blog/addon/templates/index.hbs
+++ b/tests/dummy/lib/ember-blog/addon/templates/index.hbs
@@ -1,0 +1,5 @@
+<ul>
+  <li>{{#link-to 'post' 1 class="routable-post-1-link"}}Go to post #1{{/link-to}}</li>
+  <li>{{#link-to 'post' 1 (query-params lang="Japanese") class="routable-post-1-link-jp"}}Go to post #1 with Japanese as language{{/link-to}}</li>
+  <li><button {{action "goToPostWithChinese"}} class="routable-post-1-link-ch">Go to post #1 with Chinese as language programmatically</button></li>
+</ul>

--- a/tests/dummy/lib/ember-blog/addon/templates/post.hbs
+++ b/tests/dummy/lib/ember-blog/addon/templates/post.hbs
@@ -9,3 +9,7 @@
 {{outlet}}
 
 {{#link-to-external "home" class="routable-post-home-link"}}Go home{{/link-to-external}}
+{{#link-to "index" class="routable-post-blog-home-link"}}Go to blog home{{/link-to}}
+
+{{#link-to (query-params lang="Japanese") class="routable-post-jp-link"}}Go to Japanese version{{/link-to}}
+<button {{action "goToChineseVersion"}} class="routable-post-ch-link">Go to Chinese version</button>


### PR DESCRIPTION
Addresses #209.

This should cover a large swath of Engines + QP use cases. There is a [super tiny change that needs to happen upstream](https://github.com/emberjs/ember.js/pull/14487) in order for this to pass.