### PR TITLE
fix: lock broccoli-funnel to prevent rebuild error

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "broccoli-babel-transpiler": "^5.5.0",
     "broccoli-concat": "^3.0.1",
     "broccoli-file-creator": "^1.1.0",
-    "broccoli-funnel": "^1.0.0",
+    "broccoli-funnel": "1.0.6",
     "path-posix": "1.0.0",
     "broccoli-merge-trees": "^1.0.0",
     "broccoli-plugin": "^1.2.1",


### PR DESCRIPTION
Temporary fix until we find the problem in broccoli-funnel. This fixes errors
of the following nature:

```
The Broccoli Plugin: [BroccoliMergeTrees] failed with:
Error: ENOENT: no such file or directory, lstat '/Users/iradchenko/sandbox/ember-admin-demo/tmp/funnel-output_path-TLi8yNpH.tmp'
    at Error (native)
    at Object.fs.lstatSync (fs.js:982:18)
    at symlink (/Users/iradchenko/sandbox/ember-engines/node_modules/symlink-or-copy/index.js:60:26)
    at symlinkOrCopySync (/Users/iradchenko/sandbox/ember-engines/node_modules/symlink-or-copy/index.js:55:5)
    at /Users/iradchenko/sandbox/ember-engines/node_modules/broccoli-plugin/read_compat.js:58:9
    at tryCatch (/Users/iradchenko/sandbox/ember-engines/node_modules/rsvp/dist/rsvp.js:538:12)
    at invokeCallback (/Users/iradchenko/sandbox/ember-engines/node_modules/rsvp/dist/rsvp.js:553:13)
    at publish (/Users/iradchenko/sandbox/ember-engines/node_modules/rsvp/dist/rsvp.js:521:7)
    at flush (/Users/iradchenko/sandbox/ember-engines/node_modules/rsvp/dist/rsvp.js:2373:5)
    at _combinedTickCallback (internal/process/next_tick.js:67:7)
    at process._tickCallback (internal/process/next_tick.js:98:9)

The broccoli plugin was instantiated at: 
    at BroccoliMergeTrees.Plugin (/Users/iradchenko/sandbox/ember-engines/node_modules/broccoli-plugin/index.js:7:31)
    at new BroccoliMergeTrees (/Users/iradchenko/sandbox/ember-engines/node_modules/broccoli-merge-trees/index.js:42:10)
    at BroccoliMergeTrees (/Users/iradchenko/sandbox/ember-engines/node_modules/broccoli-merge-trees/index.js:36:53)
    at CoreObject.treeForPublic (/Users/iradchenko/sandbox/ember-engines/lib/engine-addon.js:369:46)
    at CoreObject._treeFor (/Users/iradchenko/sandbox/ember-admin-demo/node_modules/ember-cli/lib/models/addon.js:371:33)
    at CoreObject.treeFor (/Users/iradchenko/sandbox/ember-engines/lib/engine-addon.js:624:23)
    at /Users/iradchenko/sandbox/ember-admin-demo/node_modules/ember-cli/lib/broccoli/ember-app.js:498:20
    at Array.map (native)
    at EmberApp.addonTreesFor (/Users/iradchenko/sandbox/ember-admin-demo/node_modules/ember-cli/lib/broccoli/ember-app.js:496:30)
    at EmberApp.publicTree (/Users/iradchenko/sandbox/ember-admin-demo/node_modules/ember-cli/lib/broccoli/ember-app.js:773:20)
```

when the parent app rebuilds from a change in an engine.

cc @nathanhammond @hyderali