### PR TITLE
Specify allowEmpty to enable child engines to be safely merged.

### DIFF
--- a/lib/engine-addon.js
+++ b/lib/engine-addon.js
@@ -360,7 +360,8 @@ module.exports = {
         var childAddonsPublicTreesMerged = mergeTrees(childAddonsPublicTrees, { overwrite: true });
         var childLazyEngines = new Funnel(childAddonsPublicTreesMerged, {
           srcDir: 'engines-dist',
-          destDir: 'engines-dist'
+          destDir: 'engines-dist',
+          allowEmpty: true
         });
         var childAddonsPublicTreesRelocated = new Funnel(childAddonsPublicTreesMerged, {
           exclude: ['engines-dist', 'engines-dist/**/*.*'],


### PR DESCRIPTION
This flag should have always been set, but implementation details meant that it wasn't required to be in the past. Recent updates to `broccoli-funnel` "fixed" the non-throwing error, but only on rebuilds, and it's not actively throwing a helpful error, just encountering one and bailing.

Updates to broccoli-funnel messaging coming momentarily.

/cc @stefanpenner @trentmwillis 