### PR TITLE
Re-export link-to-external so that it is available in integration tests

### DIFF
--- a/addon/-private/link-to-external-component.js
+++ b/addon/-private/link-to-external-component.js
@@ -13,8 +13,11 @@ export default LinkComponent.extend({
     this._super(...arguments);
 
     const owner = getOwner(this);
-    const targetRouteName = get(this, 'targetRouteName');
-    const externalRoute = owner._getExternalRoute(targetRouteName);
-    set(this, 'targetRouteName', externalRoute);
+
+    if (owner.mountPoint) {
+      const targetRouteName = get(this, 'targetRouteName');
+      const externalRoute = owner._getExternalRoute(targetRouteName);
+      set(this, 'targetRouteName', externalRoute);
+    }
   }
 });

--- a/app/components/link-to-external.js
+++ b/app/components/link-to-external.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-engines/-private/link-to-external-component';

--- a/tests/integration/component-with-link-to-external-test.js
+++ b/tests/integration/component-with-link-to-external-test.js
@@ -1,0 +1,25 @@
+import Ember from 'ember';
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('component-with-link-to-external', 'Integration | Component | component-with-link-to-external', {
+  integration: true,
+
+  beforeEach() {
+    let testComponent = Ember.Component.extend();
+    this.registry.register('component:test-component', testComponent);
+  }
+});
+
+test('component renders with link-to-external', function(assert) {
+  assert.expect(1);
+
+  this.render(hbs`
+    {{#test-component}}
+      {{#link-to "view"}}Link To{{/link-to}}
+      {{#link-to-external "view"}}Link To External{{/link-to-external}}
+    {{/test-component}}
+  `);
+
+  assert.equal(this.$().length, 1);
+});


### PR DESCRIPTION
Porting forward the main part of #205.