### PR TITLE
Add tests for loading/error states

### DIFF
--- a/tests/acceptance/routeable-engine-demo-test.js
+++ b/tests/acceptance/routeable-engine-demo-test.js
@@ -1,3 +1,4 @@
+import Ember from 'ember';
 import { test } from 'qunit';
 import sinon from 'sinon';
 import moduleForAcceptance from '../../tests/helpers/module-for-acceptance';
@@ -256,7 +257,7 @@ test('transitionTo works properly within parent application', function(assert) {
   });
 });
 
-test('intermediateTransitionTo to a loaded route works within an Engine', function(assert) {
+test('loading routes and intermediateTransitionTo work within an engine', function(assert) {
   assert.expect(2);
 
   this.application.__container__.lookup('router:main').reopen({
@@ -270,6 +271,29 @@ test('intermediateTransitionTo to a loaded route works within an Engine', functi
   click('.routable-post-likes-link');
   andThen(() => {
     assert.equal(currentURL(), '/routable-engine-demo/blog/post/1/likes');
+  });
+});
+
+test('error routes and intermediateTransitionTo work within an engine', function(assert) {
+  assert.expect(3);
+
+  let originalExceptionHandler = Ember.Test.adapter.exception;
+  Ember.Test.adapter.exception = () => {};
+
+  this.application.__container__.lookup('router:main').reopen({
+    intermediateTransitionTo(routeName) {
+      assert.equal(routeName, 'blog.post.error');
+      this._super(...arguments);
+    }
+  });
+
+  visit('/routable-engine-demo/blog/post/1/comments');
+  click('.routable-post-diggs-link');
+  andThen(() => {
+    assert.equal(currentURL(), '/routable-engine-demo/blog/post/1/comments');
+    assert.equal(find('.error-message').text(), 'Error: Nope!');
+
+    Ember.Test.adapter.exception = originalExceptionHandler;
   });
 });
 

--- a/tests/dummy/lib/ember-blog/addon/routes.js
+++ b/tests/dummy/lib/ember-blog/addon/routes.js
@@ -10,5 +10,8 @@ export default buildRoutes(function() {
 
     // The likes route loads slowly to test loading states
     this.route('likes');
+
+    // The diggs route throws an error to test error states
+    this.route('diggs');
   });
 });

--- a/tests/dummy/lib/ember-blog/addon/routes/post.js
+++ b/tests/dummy/lib/ember-blog/addon/routes/post.js
@@ -13,12 +13,6 @@ export default Ember.Route.extend({
   actions: {
     goToChineseVersion() {
       this.transitionTo({ queryParams: { lang: 'Chinese' } });
-    },
-
-    loading() {
-      // Manually invoking the loading route since loading states
-      // do not currently work properly. Should fix soon.
-      this.intermediateTransitionTo('post.loading');
     }
   }
 });

--- a/tests/dummy/lib/ember-blog/addon/routes/post/diggs.js
+++ b/tests/dummy/lib/ember-blog/addon/routes/post/diggs.js
@@ -1,0 +1,9 @@
+import Ember from 'ember';
+
+const { RSVP } = Ember;
+
+export default Ember.Route.extend({
+  model() {
+    return RSVP.reject(new Error('Nope!'));
+  }
+});

--- a/tests/dummy/lib/ember-blog/addon/templates/post.hbs
+++ b/tests/dummy/lib/ember-blog/addon/templates/post.hbs
@@ -7,6 +7,7 @@
 <p>
   {{#link-to "post.comments" 1 class="routable-post-comments-link"}}Comments{{/link-to}}
   {{#link-to "post.likes" 1 class="routable-post-likes-link"}}Likes{{/link-to}}
+  {{#link-to "post.diggs" 1 class="routable-post-diggs-link"}}Diggs{{/link-to}}
 </p>
 
 {{outlet}}

--- a/tests/dummy/lib/ember-blog/addon/templates/post/error.hbs
+++ b/tests/dummy/lib/ember-blog/addon/templates/post/error.hbs
@@ -1,0 +1,1 @@
+<h2 class="error-message">Error: {{model.message}}</h2>


### PR DESCRIPTION
Verifying that https://github.com/emberjs/ember.js/pull/14545 does what it needs to in this addon. Should restart the CI processes once the upstream PR lands.