### PR TITLE
Work smarter, not harder.

### DIFF
--- a/lib/engine-addon.js
+++ b/lib/engine-addon.js
@@ -267,6 +267,10 @@ module.exports = {
       };
 
       this.treeForEngine = function() {
+        // If this engine is lazy or any of its parents are lazy we need to promote its routes.
+        var needsRoutePromotion = (findHost.call(this) !== findRoot.call(this));
+        if (!needsRoutePromotion) { return; }
+
         // The only thing that we want to promote from a lazy engine is the routes.js file.
         // ... and all of its dependencies.
 
@@ -301,28 +305,36 @@ module.exports = {
         var childAppTree = buildChildAppTree.call(this);
         var configTree = buildConfigTree.call(this, '/modules/' + this.name);
 
-        var engineOtherTree = new Funnel(engineTree, {
-          exclude: ['modules', 'modules/**/*.*']
-        });
+        // If this engine is lazy or any of its parents are lazy we need to remove its routes.
+        var needsRouteRemoval = (findHost.call(this) !== findRoot.call(this));
 
-        var engineJSTreeThere = new Funnel(engineTree, {
-          srcDir: 'modules',
-          allowEmpty: true
-        });
+        var engineBigHappyFamily;
+        if (needsRouteRemoval) {
+          var engineOtherTree = new Funnel(engineTree, {
+            exclude: ['modules', 'modules/**/*.*']
+          });
 
-        // But we've already accounted for our routes with the `treeForEngine` hook.
-        var engineJSTreeWithoutRoutes = rollupFunnel(engineJSTreeThere, {
-          exclude: true,
-          rollup: {
-            entry: this.name+'/routes.js'
-          }
-        });
+          var engineJSTreeThere = new Funnel(engineTree, {
+            srcDir: 'modules',
+            allowEmpty: true
+          });
 
-        var engineJSTreeBackAgain = new Funnel(engineJSTreeWithoutRoutes, {
-          destDir: 'modules'
-        });
+          // But we've already accounted for our routes with the `treeForEngine` hook.
+          var engineJSTreeWithoutRoutes = rollupFunnel(engineJSTreeThere, {
+            exclude: true,
+            rollup: {
+              entry: this.name+'/routes.js'
+            }
+          });
 
-        var engineBigHappyFamily = mergeTrees([engineJSTreeBackAgain, engineOtherTree]);
+          var engineJSTreeBackAgain = new Funnel(engineJSTreeWithoutRoutes, {
+            destDir: 'modules'
+          });
+
+          engineBigHappyFamily = mergeTrees([engineJSTreeBackAgain, engineOtherTree])
+        } else {
+          engineBigHappyFamily = engineTree;
+        }
 
         var childAppTreeRelocated = new Funnel(childAppTree, {
           destDir: 'modules/' + this.name

--- a/lib/engine-addon.js
+++ b/lib/engine-addon.js
@@ -281,7 +281,8 @@ module.exports = {
         var engineRoutesTree = rollupFunnel(completeJSTree, {
           include: true,
           rollup: {
-            entry: this.name+'/routes.js'
+            entry: this.name+'/routes.js',
+            external: ['ember-engines/routes']
           }
         });
 
@@ -323,7 +324,8 @@ module.exports = {
           var engineJSTreeWithoutRoutes = rollupFunnel(engineJSTreeThere, {
             exclude: true,
             rollup: {
-              entry: this.name+'/routes.js'
+              entry: this.name+'/routes.js',
+              external: ['ember-engines/routes']
             }
           });
 
@@ -402,7 +404,8 @@ module.exports = {
         var engineAppTreeWithoutRoutes = rollupFunnel(engineAppTree, {
           exclude: true,
           rollup: {
-            entry: this.name+'/routes.js'
+            entry: this.name+'/routes.js',
+            external: ['ember-engines/routes']
           }
         });
 

--- a/lib/engine-addon.js
+++ b/lib/engine-addon.js
@@ -21,6 +21,34 @@ var DEFAULT_CONFIG = {
   }
 };
 
+
+function findRoot() {
+  var current = this;
+  var app;
+
+  // Keep iterating upward until we don't have a grandparent.
+  // Has to do this grandparent check because at some point we hit the project.
+  do {
+    app = current.app || app;
+  } while (current.parent.parent && (current = current.parent));
+
+  return app;
+}
+
+function findHost() {
+  var current = this;
+  var app;
+
+  // Keep iterating upward until we don't have a grandparent.
+  // Has to do this grandparent check because at some point we hit the project.
+  do {
+    if (current.lazyLoading === true) { return current; }
+    app = current.app || app;
+  } while (current.parent.parent && (current = current.parent));
+
+  return app;
+}
+
 /**
   This is an extraction of what would normally be run by the `treeFor` hook.
   Because we call it in two different places we've moved it to a utility function.
@@ -186,33 +214,10 @@ module.exports = {
 
       // Change the host inside of engines.
       // Support pre-2.7 Ember CLI.
-      var originalFindHost = this._findHost || function() {
-        var current = this;
-        var app;
-
-        // Keep iterating upward until we don't have a grandparent.
-        // Has to do this grandparent check because at some point we hit the project.
-        do {
-          app = current.app || app;
-        } while (current.parent.parent && (current = current.parent));
-
-        return app;
-      };
+      var originalFindHost = this._findHost || findRoot;
 
       // Unfortunately results in duplication, but c'est la vie.
-      this._findHost = function() {
-        var current = this;
-        var app;
-
-        // Keep iterating upward until we don't have a grandparent.
-        // Has to do this grandparent check because at some point we hit the project.
-        do {
-          if (current.lazyLoading === true) { return current; }
-          app = current.app || app;
-        } while (current.parent.parent && (current = current.parent));
-
-        return app;
-      };
+      this._findHost = findHost;
 
       this.otherAssetPaths = [];
       this._scriptOutputFiles = {};

--- a/lib/engine-addon.js
+++ b/lib/engine-addon.js
@@ -296,6 +296,29 @@ module.exports = {
         var childAppTree = buildChildAppTree.call(this);
         var configTree = buildConfigTree.call(this, '/modules/' + this.name);
 
+        var engineOtherTree = new Funnel(engineTree, {
+          exclude: ['modules', 'modules/**/*.*']
+        });
+
+        var engineJSTreeThere = new Funnel(engineTree, {
+          srcDir: 'modules',
+          allowEmpty: true
+        });
+
+        // But we've already accounted for our routes with the `treeForEngine` hook.
+        var engineJSTreeWithoutRoutes = rollupFunnel(engineJSTreeThere, {
+          exclude: true,
+          rollup: {
+            entry: this.name+'/routes.js'
+          }
+        });
+
+        var engineJSTreeBackAgain = new Funnel(engineJSTreeWithoutRoutes, {
+          destDir: 'modules'
+        });
+
+        var engineBigHappyFamily = mergeTrees([engineJSTreeBackAgain, engineOtherTree]);
+
         var childAppTreeRelocated = new Funnel(childAppTree, {
           destDir: 'modules/' + this.name
         });
@@ -307,7 +330,7 @@ module.exports = {
           externalTree = buildExternalTree.call(this);
         }
 
-        return mergeTrees([externalTree, childAppTreeRelocated, engineTree, configTree].filter(Boolean), { overwrite: true });
+        return mergeTrees([externalTree, childAppTreeRelocated, engineBigHappyFamily, configTree].filter(Boolean), { overwrite: true });
       };
 
       // We want to do the default `treeForPublic` behavior if we're not a lazy loading engine.
@@ -596,7 +619,7 @@ module.exports = {
         trees = this.eachAddonInvoke('treeFor', [name]);
       }
 
-      if (name === 'addon' && source !== 'buildVendorTree' && this.lazyLoading === true) {
+      if (name === 'addon' && source !== 'buildVendorTree') {
         trees = trees.concat(this.eachAddonInvoke('treeForEngine', [this]));
         trees.push(this.treeForEngine());
       }

--- a/lib/rollup-funnel.js
+++ b/lib/rollup-funnel.js
@@ -70,6 +70,7 @@ RollupFunnel.prototype.build = function() {
 
   var rollupOptions = {
     entry: this.options.rollup.entry,
+    external: this.options.rollup.external || [],
     dest: 'foo.js',
     plugins: [
       {


### PR DESCRIPTION
Currently `ember-engines` does unnecessary work in an all-eager scenario to remove and re-add routes. This stops that madness.

Manually tested that this produces identical output for the [`lazy-engine-testing`](https://github.com/nathanhammond/lazy-engine-testing) repo.