### PR TITLE
Use correct link-to method for 2.9.0.

### DIFF
--- a/addon/-private/link-to-utils.js
+++ b/addon/-private/link-to-utils.js
@@ -9,7 +9,7 @@ export default function hasEmberVersion(major, minor) {
 }
 
 export const attributeMungingMethod = (function() {
-  if (hasEmberVersion(2, 9)) {
+  if (hasEmberVersion(2, 10)) {
     return 'didReceiveAttrs';
   } else {
     return `willRender`;


### PR DESCRIPTION
See http://emberjs.com/blog/2016/10/17/ember-2-9-released.html for details.